### PR TITLE
refactor(lib)!: create and expose a single `Template` object for users to interact with

### DIFF
--- a/benches/process.rs
+++ b/benches/process.rs
@@ -1,26 +1,24 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
-use string_pipeline::process;
+use string_pipeline::Template;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("process_simple", |b| {
         b.iter(|| {
-            process(
-                black_box("/home/user/.cargo/bin"),
-                // output: "bin"
-                black_box("{split:/:-1}"),
-            )
-            .unwrap()
+            Template::parse(black_box("{split:/:-1}"))
+                .unwrap()
+                .format(black_box("/home/user/.cargo/bin"))
+                .unwrap()
         })
     });
 
     c.bench_function("process_complex", |b| {
         b.iter(|| {
-            process(
-                black_box(" 18,   4.92, Unknown"),
-                // output: "NUM: 18 - NUM: 4.92"
-                black_box("{split:,:0..2|trim|prepend:num\\: |join: - |upper}"),
-            )
+            Template::parse(black_box(
+                "{split:,:0..2|trim|prepend:num\\: |join: - |upper}",
+            ))
+            .unwrap()
+            .format(black_box("18,   4.92, Unknown"))
             .unwrap()
         })
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,70 @@
 //! # string_pipeline
 //!
 //! A flexible, template-driven string transformation pipeline for Rust.
+//!
+//! This library provides a way to define a sequence of string operations using a concise template syntax,
+//! allowing for dynamic string manipulation based on user-defined templates.
+//!
+//! # Quick start
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! // Define a template with operations
+//! let template = Template::parse("{split:,:0..2|join: and }").unwrap();
+//!
+//! // Format a string using the template
+//! let result = template.format("a,b,c,d").unwrap();
+//!
+//! assert_eq!(result, "a and b");
+//! ```
+//!
+//! A more in-depth view of the template syntax can be found in the [Template::parse](Template::parse) method documentation.
+//!
+//! # More examples
+//! Get the second item in a comma-separated list:
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("{split:,:1}").unwrap();
+//!
+//! let result = template.format("a,b,c").unwrap();
+//!
+//! assert_eq!(result, "b");
+//! ```
+//!
+//! Replace all spaces with underscores and uppercase:
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("{replace:s/ /_/g|upper}").unwrap();
+//!
+//! let result = template.format("foo bar baz").unwrap();
+//!
+//! assert_eq!(result, "FOO_BAR_BAZ");
+//! ```
+//!
+//! Trim, split and append a suffix to each resulting item:
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("{split:,:..|trim|append:!}").unwrap();
+//!
+//! let result = template.format(" a, b,c , d , e ").unwrap();
+//!
+//! assert_eq!(result, "a!,b!,c!,d!,e!");
+//! ```
+//!
+//! Strip ANSI escape codes:
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("{strip_ansi}").unwrap();
+//!
+//! let result = template.format("\x1b[31mHello\x1b[0m").unwrap();
+//!
+//! assert_eq!(result, "Hello");
+//! ```
 
 mod pipeline;
 
-pub use pipeline::apply_ops;
-pub use pipeline::parse_template;
-pub use pipeline::process;
-pub use pipeline::{RangeSpec, StringOp, Value};
+pub use pipeline::Template;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use std::io::{self, Read};
-use string_pipeline::process;
+use string_pipeline::Template;
 
 #[derive(Parser)]
 struct Cli {
@@ -33,10 +33,15 @@ fn main() {
         },
     };
 
-    match process(&input, &cli.template) {
+    let template = Template::parse(&cli.template).unwrap_or_else(|e| {
+        eprintln!("Error parsing template: {}", e);
+        std::process::exit(1);
+    });
+
+    match template.format(&input) {
         Ok(result) => println!("{}", result),
         Err(e) => {
-            eprintln!("Error: {}", e);
+            eprintln!("Error formatting input: {}", e);
             std::process::exit(1);
         }
     }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -2,8 +2,11 @@ use regex::Regex;
 mod parser;
 use strip_ansi_escapes::strip;
 
+pub use crate::pipeline::template::Template;
+mod template;
+
 #[derive(Debug, Clone)]
-pub enum Value {
+enum Value {
     Str(String),
     List(Vec<String>),
 }
@@ -53,10 +56,6 @@ pub enum StringOp {
 pub enum RangeSpec {
     Index(isize),
     Range(Option<isize>, Option<isize>, bool), // (start, end, inclusive)
-}
-
-pub fn parse_template(template: &str) -> Result<(Vec<StringOp>, bool), String> {
-    parser::parse_template(template)
 }
 
 fn resolve_index(idx: isize, len: usize) -> usize {
@@ -380,21 +379,20 @@ pub fn apply_ops(input: &str, ops: &[StringOp], debug: bool) -> Result<String, S
     })
 }
 
-pub fn process(input: &str, template: &str) -> Result<String, String> {
-    let (ops, debug) = parse_template(template)?;
-    apply_ops(input, &ops, debug)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Template;
+
+    fn process(input: &str, template: &str) -> Result<String, String> {
+        let tmpl = Template::parse(template)?;
+        tmpl.format(input)
+    }
 
     // Single Operation Tests - Organized by Operation Type
     mod single_operations {
-        use super::*;
 
         mod positive_tests {
-            use super::*;
+            use super::super::process;
 
             // Split operation tests
             #[test]
@@ -979,7 +977,7 @@ mod tests {
         }
 
         mod negative_tests {
-            use super::*;
+            use super::super::process;
 
             // Split operation negative tests
             #[test]
@@ -1111,11 +1109,8 @@ mod tests {
 
     // Two-Step Pipeline Tests
     mod two_step_pipelines {
-        use super::*;
-
         mod positive_tests {
-            use super::*;
-
+            use super::super::process;
             // Split + Join combinations
             #[test]
             fn test_split_join_different_separators() {
@@ -1379,7 +1374,7 @@ mod tests {
         }
 
         mod negative_tests {
-            use super::*;
+            use super::super::process;
 
             // Invalid pipeline combinations
             #[test]
@@ -1430,10 +1425,8 @@ mod tests {
 
     // Multi-Step Pipeline Tests
     mod multi_step_pipelines {
-        use super::*;
-
         mod positive_tests {
-            use super::*;
+            use super::super::process;
 
             // Split + Transform + Join patterns
             #[test]
@@ -2135,7 +2128,7 @@ mod tests {
         }
 
         mod negative_tests {
-            use super::*;
+            use super::super::process;
 
             // Invalid three-step combinations
             #[test]

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -1,0 +1,179 @@
+use std::fmt::Display;
+
+use crate::pipeline::{StringOp, apply_ops, parser};
+
+/// A `Template` represents a string template with operations that can be applied to format input
+/// strings.
+///
+/// It allows defining a sequence of operations to transform input strings, such as splitting,
+/// joining, replacing, trimming, and more. The template is parsed from a string format that
+/// specifies the operations in a concise syntax.
+///
+/// The template syntax supports a variety of operations, including:
+/// - **Split**
+/// - **Join**
+/// - **Substring extraction**
+/// - **Sed-like replacement using regex**
+/// - **Uppercase and lowercase conversion**
+/// - **Trimming whitespace or custom characters**
+/// - **Appending or prepending text**
+/// - etc.
+///
+/// A `Template` can be created by parsing a string that follows the defined syntax (see
+/// `Template::parse`), and it can then be used to format input strings by applying the specified
+/// operations in sequence.
+///
+/// # Example
+/// Trim, split and append a suffix to each resulting item:
+/// ```rust
+/// use string_pipeline::Template;
+///
+/// let template = Template::parse("{split:,:..|trim|append:!}").unwrap();
+///
+/// let result = template.format(" a, b,c , d , e ").unwrap();
+///
+/// assert_eq!(result, "a!,b!,c!,d!,e!");
+/// ```
+#[derive(Debug)]
+pub struct Template {
+    /// The raw template string.
+    raw: String,
+    /// A series of string operations to apply to the target string.
+    ops: Vec<StringOp>,
+    /// Whether to enable debug mode, which provides additional output for debugging purposes.
+    debug: bool,
+}
+
+impl Template {
+    fn new(raw: String, ops: Vec<StringOp>, debug: bool) -> Self {
+        Template { raw, ops, debug }
+    }
+
+    /// Attempts to Parse a template string into a `Template` object.
+    ///
+    /// Templates are enclosed in `{}` and consist of a chain of operations separated by `|`.
+    /// Arguments to operations are separated by `:`.
+    ///
+    /// # Syntax Reference
+    ///
+    /// - **Template**: `{ [!] operation_list? }`
+    ///   - Add `!` after `{` to enable debug mode.
+    /// - **Operation List**: `operation ('|' operation)*`
+    /// - **Operation**:
+    ///   - `split:<sep>:<range>`
+    ///     - **Shorthand for split**:
+    ///       - `{index}` (e.g. `{1}`, equivalent to `{split: :1}`)
+    ///       - `{range}` (e.g. `{1..3}`, equivalent to `{split: :1..3}`)
+    ///   - `join:<sep>`
+    ///   - `substring:<range>`
+    ///   - `replace:s/<pattern>/<replacement>/<flags>`
+    ///   - `upper`
+    ///   - `lower`
+    ///   - `trim`
+    ///   - `strip:<chars>`
+    ///   - `append:<suffix>`
+    ///   - `prepend:<prefix>`
+    ///   - `strip_ansi`
+    ///   - `filter:<regex_pattern>`
+    ///   - `filter_not:<regex_pattern>`
+    ///   - `slice:<range>`
+    ///
+    /// ## Supported Operations
+    ///
+    /// | Operation         | Syntax                                      | Description                                 |
+    /// |-------------------|---------------------------------------------|---------------------------------------------|
+    /// | Split             | `split:<sep>:<range>`                         | Split by separator, select by index/range   |
+    /// | Join              | `join:<sep>`                                  | Join a list with separator                  |
+    /// | Substring         | `slice:<range>`                               | Extract substrings                          |
+    /// | Replace           | `replace:s/<pattern>/<replacement>/<flags>`   | Regex replace (sed-like)                    |
+    /// | Uppercase         | `upper`                                       | Convert to uppercase                        |
+    /// | Lowercase         | `lower`                                       | Convert to lowercase                        |
+    /// | Trim              | `trim`                                        | Trim whitespace                             |
+    /// | Strip             | `strip:<chars>`                               | Trim custom characters                      |
+    /// | Append            | `append:<suffix>`                             | Append text                                 |
+    /// | Prepend           | `prepend:<prefix>`                            | Prepend text                                |
+    /// | StripAnsi         | `strip_ansi`                                  | Removes ansi escape sequences               |
+    /// | Filter            | `filter:<regex_pattern>`                      | Keep only items matching regex pattern      |
+    /// | FilterNot         | `filter_not:<regex_pattern>`                  | Remove items matching regex pattern         |
+    /// | Slice             | `filter_not:<regex_pattern>`                  | Select elements from a list                 |
+    ///
+    /// ## Range Specifications
+    ///
+    /// Ranges use Rust-like syntax and support negative indices like Python:
+    ///
+    /// | Range | Description | Example |
+    /// |-------|-------------|---------|
+    /// | `N` | Single index | `{split:,:1}` → second element |
+    /// | `N..M` | Exclusive range | `{split:,:1..3}` → elements 1,2 |
+    /// | `N..=M` | Inclusive range | `{split:,:1..=3}` → elements 1,2,3 |
+    /// | `N..` | From N to end | `{split:,:2..}` → from 2nd to end |
+    /// | `..N` | From start to N | `{split:,:..3}` → first 3 elements |
+    /// | `..=N` | From start to N inclusive | `{split:,:..=2}` → first 3 elements |
+    /// | `..` | All elements | `{split:,:..)` → all elements |
+    ///
+    /// Negative indices count from the end:
+    ///
+    /// - `-1` = last element
+    /// - `-2` = second to last element
+    /// - `-3..` = last 3 elements
+    ///
+    /// ## Escaping
+    ///
+    /// The parser intelligently handles pipe characters (`|`) based on context:
+    ///
+    /// **Pipes are automatically allowed in:**
+    ///
+    /// - **Split separators**: `{split:|:..}` (splits on pipe)
+    /// - **Regex patterns**: `{filter:\.(txt|md|log)}` (alternation)
+    /// - **Sed replacements**: `{replace:s/test/a|b/}` (pipe in replacement)
+    ///
+    /// **Manual escaping needed for:**
+    ///
+    /// - **Other arguments**: Use `\|` for literal pipes in join, append, prepend, etc.
+    /// - **Special characters**: Use `\:` for literal colons, `\\` for backslashes
+    /// - **Escape sequences**: Use `\n`, `\t`, `\r` for newline, tab, carriage return
+    ///
+    /// ## Enable Debug Mode
+    ///
+    /// - Add `!` after `{` to enable debug output for each operation:
+    /// - Example: `{!split:,:..|upper|join:-}`
+    pub fn parse(template: &str) -> Result<Self, String> {
+        match parser::parse_template(template) {
+            Ok((ops, debug)) => Ok(Template::new(template.to_string(), ops, debug)),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Formats the input string using the operations defined in the template.
+    ///
+    /// # Example
+    /// ```rust
+    /// use string_pipeline::Template;
+    ///
+    /// // Create a template that splits a string by commas, takes the first two items, and joins
+    /// // them with " and "
+    /// let template = Template::parse("{split:,:0..2|join: and }").unwrap();
+    ///
+    /// // Format a string using the template
+    /// let result = template.format("a,b,c,d").unwrap();
+    ///
+    /// assert_eq!(result, "a and b");
+    /// ```
+    pub fn format(&self, input: &str) -> Result<String, String> {
+        apply_ops(input, &self.ops, self.debug)
+    }
+}
+
+impl TryFrom<&str> for Template {
+    type Error = String;
+
+    fn try_from(template: &str) -> Result<Self, Self::Error> {
+        Template::parse(template)
+    }
+}
+
+impl Display for Template {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}


### PR DESCRIPTION
Having put a bit of thought into how to use this with television, I felt like this would be a more natural and intuitive interface for the lib.

The `Template` becomes the god-object and is the only thing exposed to the end user which makes it clearer for the user - in my view - what's happening (with `Template::parse` and `Template::format` being the only public entrypoints).

This also enables hiding things such as `StringOps` etc. which I believe the user doesn't need to be aware of.

Other nice thing is the user can now parse a template once and keep it lying around to format any number of strings (typically television's usecase).

Don't hesitate if anything's unclear,
Cheers,

And again, great work on the project!


PS: added a bit of documentation, feel free to update/remove that if you don't believe it's worth it.