### PR TITLE
feat(ci): add manual baseline update workflow and update benchmark sizes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           # Run benchmarks with multiple sizes and save to JSON
           ./target/release/bench_throughput \
-            --sizes 100,1000,10000 \
+            --sizes 1000,10000,100000 \
             --iterations 50 \
             --format json \
             --output benchmark_results.json
@@ -85,14 +85,6 @@ jobs:
           path: |
             benchmark_results.json
             comparison.md
-
-      - name: Upload as baseline (main branch only)
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-baseline
-          path: benchmark_results.json
-          retention-days: 90
 
       - name: Fail if significant performance regression
         if: steps.compare.outputs.comparison_available == 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           # Run benchmarks with multiple sizes and save to JSON
           ./target/release/bench_throughput \
-            --sizes 1000,10000,100000 \
-            --iterations 50 \
+            --sizes 1000,5000,10000 \
+            --iterations 100 \
             --format json \
             --output benchmark_results.json
 

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -1,0 +1,76 @@
+name: Update Benchmark Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (tag, branch, or commit SHA) to benchmark'
+        required: true
+        default: 'main'
+        type: string
+      iterations:
+        description: 'Number of benchmark iterations'
+        required: false
+        default: '50'
+        type: string
+
+jobs:
+  update-baseline:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository at specified ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Get commit info
+        id: commit-info
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(git log -1 --format=%ci)" >> $GITHUB_OUTPUT
+          echo "message=$(git log -1 --format=%s)" >> $GITHUB_OUTPUT
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build benchmark tool
+        run: cargo build --release --bin bench_throughput
+
+      - name: Run benchmarks
+        run: |
+          echo "Running benchmarks for commit ${{ steps.commit-info.outputs.short_sha }}"
+          ./target/release/bench_throughput \
+            --sizes 1000,10000,100000 \
+            --iterations ${{ inputs.iterations }} \
+            --format json \
+            --output benchmark_results.json
+
+      - name: Add workflow summary
+        run: |
+          echo "## Baseline Update Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Reference:** \`${{ inputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ steps.commit-info.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Date:** ${{ steps.commit-info.outputs.date }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Message:** ${{ steps.commit-info.outputs.message }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Baseline has been updated successfully." >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload new baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline
+          path: benchmark_results.json
+          retention-days: 90
+
+      - name: Baseline updated successfully
+        run: |
+          echo "::notice::Baseline successfully updated to commit ${{ steps.commit-info.outputs.short_sha }}"

--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -11,7 +11,7 @@ on:
       iterations:
         description: 'Number of benchmark iterations'
         required: false
-        default: '50'
+        default: '100'
         type: string
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "Running benchmarks for commit ${{ steps.commit-info.outputs.short_sha }}"
           ./target/release/bench_throughput \
-            --sizes 1000,10000,100000 \
+            --sizes 1000,5000,10000 \
             --iterations ${{ inputs.iterations }} \
             --format json \
             --output benchmark_results.json


### PR DESCRIPTION
- Remove automatic baseline updates from benchmark.yml (main branch pushes)
- Add new update-baseline.yml workflow for manual baseline updates
  - Trigger via workflow_dispatch with ref and iterations inputs
  - Checkout specified git ref (tag/branch/commit)
  - Run benchmarks and update baseline artifact
- Update benchmark sizes from 100,1000,10000 to 1000,5000,10000
- Update iterations from 50 to 100
- Baseline updates now require explicit manual trigger via GitHub Actions UI