### PR TITLE
Bench baseline performance

### DIFF
--- a/benches/process.rs
+++ b/benches/process.rs
@@ -9,7 +9,10 @@ use string_pipeline::Template;
 // -----------------------------------------------------------------------------
 
 const SMALL_INPUT: &str = "apple,banana,cherry,date,elderberry,fig,grape,honeydew,kiwi,lemon";
+const PADDED_SMALL_INPUT: &str = " apple , banana , cherry , date , elderberry ";
+const USER_RECORD: &str = "john doe admin@example.com";
 static LARGE_INPUT: Lazy<String> = Lazy::new(|| SMALL_INPUT.repeat(1_000)); // ~600 KB
+static LARGE_MAP_INPUT: Lazy<String> = Lazy::new(|| PADDED_SMALL_INPUT.repeat(1_000));
 
 // -----------------------------------------------------------------------------
 // 1. Parsing Benchmarks – How fast can we compile templates?
@@ -17,13 +20,16 @@ static LARGE_INPUT: Lazy<String> = Lazy::new(|| SMALL_INPUT.repeat(1_000)); // ~
 
 fn bench_parsing(c: &mut Criterion) {
     let cases = [
-        ("simple", "{upper}"),
-        ("medium", "{split:,:..|join: }"),
+        ("single_block_simple", "{upper}"),
+        ("single_block_chain", "{split:,:..|map:{trim|upper}|join:,}"),
         (
-            "complex",
+            "multi_section",
+            "User: {split: :0} Email: {split: :1} Fruits: {split:,:..|sort|join:\\|}",
+        ),
+        (
+            "complex_nested",
             "{split:,:..|filter:^[a-m]|map:{trim|upper|substring:0..3}|sort|join:,}",
         ),
-        ("nested_map", "{split:,:..|map:{split:_:..|reverse}|join: }"),
     ];
 
     let mut group = c.benchmark_group("template_parsing");
@@ -42,14 +48,30 @@ fn bench_parsing(c: &mut Criterion) {
 fn bench_execution(c: &mut Criterion) {
     // (id, template, input)
     let cases = [
+        ("single_block_upper_small", "{upper}", SMALL_INPUT),
         ("split_join_small", "{split:,:..|join: }", SMALL_INPUT),
         ("split_join_large", "{split:,:..|join: }", &LARGE_INPUT),
+        (
+            "multi_section_format",
+            "Name: {split: :0} Surname: {split: :1}",
+            USER_RECORD,
+        ),
+        (
+            "repeated_split_sections",
+            "First: {split:,:0} Second: {split:,:1} Third: {split:,:2}",
+            SMALL_INPUT,
+        ),
         (
             "filter_sort",
             "{split:,:..|filter:^[a-m]|sort|join:,}",
             SMALL_INPUT,
         ),
         ("map_upper", "{split:,:..|map:{upper}|join:,}", SMALL_INPUT),
+        (
+            "map_trim_upper_large",
+            "{split:,:..|map:{trim|upper}|join:,}",
+            &LARGE_MAP_INPUT,
+        ),
         (
             "complex_nested",
             "{split:,:..|filter:^[a-m]|map:{reverse|upper}|sort|join:,}",
@@ -67,28 +89,23 @@ fn bench_execution(c: &mut Criterion) {
 }
 
 // -----------------------------------------------------------------------------
-// 3. Cache Effectiveness – First run vs subsequent runs
+// 3. Structured inputs – multi-section formatting with per-section inputs
 // -----------------------------------------------------------------------------
 
-fn bench_caching(c: &mut Criterion) {
-    let tpl_str = "{split:,:..|filter:a|join:,}";
-    let tpl = Template::parse(tpl_str).unwrap();
+fn bench_structured_inputs(c: &mut Criterion) {
+    let tpl = Template::parse("Users: {upper} | Files: {lower}").unwrap();
+    let user_inputs = ["john doe", "jane smith", "peter parker"];
+    let file_inputs = ["FILE1.TXT", "FILE2.TXT", "FILE3.TXT"];
+    let inputs: [&[&str]; 2] = [&user_inputs, &file_inputs];
+    let separators = [" ", ","];
 
-    let mut group = c.benchmark_group("cache_effect");
-
-    // Measure first-call cost (cold caches)
-    group.bench_function("first_call", |b| {
-        b.iter(|| tpl.format(black_box(SMALL_INPUT)).unwrap())
+    let mut group = c.benchmark_group("structured_inputs");
+    group.bench_function("format_with_inputs", |b| {
+        b.iter(|| {
+            tpl.format_with_inputs(black_box(&inputs), black_box(&separators))
+                .unwrap()
+        })
     });
-
-    // Warm the caches once
-    let _ = tpl.format(SMALL_INPUT).unwrap();
-
-    // Measure subsequent calls (hot caches)
-    group.bench_function("subsequent_calls", |b| {
-        b.iter(|| tpl.format(black_box(SMALL_INPUT)).unwrap())
-    });
-
     group.finish();
 }
 
@@ -102,6 +119,6 @@ criterion_group! {
         .configure_from_args()
         .sample_size(200)
         .measurement_time(Duration::from_secs(5));
-    targets = bench_parsing, bench_execution, bench_caching
+    targets = bench_parsing, bench_execution, bench_structured_inputs
 }
 criterion_main!(benches);

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -357,7 +357,7 @@ pub(crate) enum Value {
 /// [`Append`]: StringOp::Append
 /// [`Prepend`]: StringOp::Prepend
 /// [`StripAnsi`]: StringOp::StripAnsi
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub enum StringOp {
     /// Split a string by separator and optionally select a range of parts.
     ///
@@ -908,7 +908,7 @@ pub enum StringOp {
 ///
 /// [`Index`]: RangeSpec::Index
 /// [`Range`]: RangeSpec::Range
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum RangeSpec {
     /// Select a single item by index.
     ///
@@ -945,7 +945,7 @@ pub enum RangeSpec {
 /// Direction for trimming operations.
 ///
 /// Specifies which end(s) of a string to trim characters from.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum TrimDirection {
     /// Trim from both ends (default).
     Both,
@@ -958,7 +958,7 @@ pub enum TrimDirection {
 /// Direction for sorting operations.
 ///
 /// Specifies the order for sorting list items.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum SortDirection {
     /// Ascending order (A to Z).
     Asc,
@@ -969,7 +969,7 @@ pub enum SortDirection {
 /// Direction for padding operations.
 ///
 /// Specifies where to add padding characters to reach target width.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum PadDirection {
     /// Add padding to the left (right-align text).
     Left,
@@ -1118,7 +1118,7 @@ pub fn apply_ops_internal(
 
     for (i, op) in ops.iter().enumerate() {
         let step_start = if debug { Some(Instant::now()) } else { None };
-        let input_val = val.clone();
+        let input_val = if debug { Some(val.clone()) } else { None };
 
         match op {
             StringOp::Map { operations } => {
@@ -1127,7 +1127,7 @@ pub fn apply_ops_internal(
                         i + 1,
                         ops.len(),
                         op,
-                        &input_val,
+                        input_val.as_ref().unwrap(),
                         &Value::Str("processing...".to_string()),
                         Duration::from_nanos(0),
                     );
@@ -1182,7 +1182,14 @@ pub fn apply_ops_internal(
             && let Some(ref tracer) = debug_tracer
         {
             let elapsed = step_start.unwrap().elapsed();
-            tracer.operation_step(i + 1, ops.len(), op, &input_val, &val, elapsed);
+            tracer.operation_step(
+                i + 1,
+                ops.len(),
+                op,
+                input_val.as_ref().unwrap(),
+                &val,
+                elapsed,
+            );
         }
     }
 

--- a/src/pipeline/parser.rs
+++ b/src/pipeline/parser.rs
@@ -192,7 +192,7 @@ pub fn parse_multi_template(template: &str) -> Result<(Vec<TemplateSection>, boo
                     debug = true; // If any section has debug enabled, enable for the whole multi-template
                 }
 
-                sections.push(TemplateSection::Template(ops));
+                sections.push(TemplateSection::from_ops(ops));
             }
         } else {
             // Regular character, add to current literal

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -51,6 +51,7 @@ use std::hash::{Hash, Hasher};
 
 use crate::pipeline::get_cached_split;
 use crate::pipeline::{DebugTracer, RangeSpec, StringOp, apply_ops_internal, apply_range, parser}; // ← use global split cache
+use memchr::memchr_iter;
 
 /* ------------------------------------------------------------------------ */
 /*  MultiTemplate – the single implementation                               */
@@ -891,6 +892,23 @@ impl MultiTemplate {
             return Ok(self.fast_single_split(input, sep, range));
         }
 
+        /* fast path: split + join over the full input ------------------- */
+        if ops.len() == 2
+            && let [
+                StringOp::Split {
+                    sep: split_sep,
+                    range,
+                },
+                StringOp::Join { sep: join_sep },
+            ] = ops
+            && Self::is_full_range(range)
+        {
+            if let Some(t) = dbg {
+                t.cache_operation("FAST SPLIT+JOIN", "direct separator rewrite");
+            }
+            return Ok(self.fast_split_join(input, split_sep, join_sep));
+        }
+
         /* general path – memoised per call ------------------------------ */
 
         let key = CacheKey {
@@ -928,6 +946,40 @@ impl MultiTemplate {
             1 => selected[0].clone(),
             _ => selected.join(sep),
         }
+    }
+
+    #[inline]
+    fn fast_split_join(&self, input: &str, split_sep: &str, join_sep: &str) -> String {
+        if split_sep.is_empty() || split_sep == join_sep {
+            return input.to_string();
+        }
+
+        if split_sep.len() == 1 {
+            let split_byte = split_sep.as_bytes()[0];
+            let estimated_len = if join_sep.len() == 1 {
+                input.len()
+            } else {
+                let replacements = memchr_iter(split_byte, input.as_bytes()).count();
+                input.len() + replacements.saturating_mul(join_sep.len().saturating_sub(1))
+            };
+
+            let mut result = String::with_capacity(estimated_len);
+            let mut start = 0usize;
+            for idx in memchr_iter(split_byte, input.as_bytes()) {
+                result.push_str(&input[start..idx]);
+                result.push_str(join_sep);
+                start = idx + 1;
+            }
+            result.push_str(&input[start..]);
+            result
+        } else {
+            input.replace(split_sep, join_sep)
+        }
+    }
+
+    #[inline]
+    fn is_full_range(range: &RangeSpec) -> bool {
+        matches!(range, RangeSpec::Range(None, None, false))
     }
 
     fn format_operations_summary(ops: &[StringOp]) -> String {

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -129,7 +129,14 @@ pub enum TemplateSection {
     /// A literal text section that appears unchanged in the output.
     Literal(String),
     /// A template section containing a sequence of string operations to apply.
-    Template(Vec<StringOp>),
+    Template { ops: Vec<StringOp>, cache_key: u64 },
+}
+
+impl TemplateSection {
+    pub(crate) fn from_ops(ops: Vec<StringOp>) -> Self {
+        let cache_key = MultiTemplate::hash_ops(&ops);
+        Self::Template { ops, cache_key }
+    }
 }
 
 /// Type of template section for introspection and analysis.
@@ -243,7 +250,7 @@ impl TemplateCache {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct CacheKey {
     input_hash: u64,
-    ops_signature: String,
+    section_key: u64,
 }
 
 /* ------------------------------------------------------------------------ */
@@ -450,12 +457,13 @@ impl MultiTemplate {
                             tracer.separator();
                         }
                     }
-                    TemplateSection::Template(ops) => {
+                    TemplateSection::Template { ops, cache_key } => {
                         let summary = Self::format_operations_summary(ops);
                         tracer.section(idx + 1, self.sections.len(), "template", &summary);
                         let out = self.apply_template_section(
                             input,
                             ops,
+                            *cache_key,
                             input_hash,
                             &mut cache,
                             &Some(&tracer),
@@ -470,9 +478,10 @@ impl MultiTemplate {
             for section in &self.sections {
                 match section {
                     TemplateSection::Literal(text) => result.push_str(text),
-                    TemplateSection::Template(ops) => {
-                        let out =
-                            self.apply_template_section(input, ops, input_hash, &mut cache, &None)?;
+                    TemplateSection::Template { ops, cache_key } => {
+                        let out = self.apply_template_section(
+                            input, ops, *cache_key, input_hash, &mut cache, &None,
+                        )?;
                         result.push_str(&out);
                     }
                 }
@@ -534,7 +543,7 @@ impl MultiTemplate {
     pub fn template_section_count(&self) -> usize {
         self.sections
             .iter()
-            .filter(|s| matches!(s, TemplateSection::Template(_)))
+            .filter(|s| matches!(s, TemplateSection::Template { .. }))
             .count()
     }
 
@@ -712,7 +721,7 @@ impl MultiTemplate {
                 TemplateSection::Literal(text) => {
                     result.push_str(text);
                 }
-                TemplateSection::Template(ops) => {
+                TemplateSection::Template { ops, cache_key } => {
                     if template_index >= inputs.len() {
                         return Err("Internal error: template index out of bounds".to_string());
                     }
@@ -730,6 +739,7 @@ impl MultiTemplate {
                             self.apply_template_section(
                                 section_inputs[0],
                                 ops,
+                                *cache_key,
                                 input_hash,
                                 &mut cache,
                                 &None, // No debug tracing for structured processing
@@ -744,7 +754,7 @@ impl MultiTemplate {
                                 let input_hash = input_hasher.finish();
 
                                 let result = self.apply_template_section(
-                                    input, ops, input_hash, &mut cache,
+                                    input, ops, *cache_key, input_hash, &mut cache,
                                     &None, // No debug tracing for structured processing
                                 )?;
                                 results.push(result);
@@ -792,7 +802,7 @@ impl MultiTemplate {
         let mut template_index = 0;
 
         for section in &self.sections {
-            if let TemplateSection::Template(ops) = section {
+            if let TemplateSection::Template { ops, .. } = section {
                 result.push((template_index, ops));
                 template_index += 1;
             }
@@ -842,7 +852,7 @@ impl MultiTemplate {
                         operations: None,
                     });
                 }
-                TemplateSection::Template(ops) => {
+                TemplateSection::Template { ops, .. } => {
                     result.push(SectionInfo {
                         section_type: SectionType::Template,
                         overall_position,
@@ -866,6 +876,7 @@ impl MultiTemplate {
         &self,
         input: &str,
         ops: &[StringOp],
+        section_key: u64,
         input_hash: u64,
         cache: &mut TemplateCache,
         dbg: &Option<&DebugTracer>,
@@ -884,7 +895,7 @@ impl MultiTemplate {
 
         let key = CacheKey {
             input_hash,
-            ops_signature: format!("{ops:?}"),
+            section_key,
         };
 
         if let Some(cached) = cache.operations.get(&key) {
@@ -958,6 +969,16 @@ impl MultiTemplate {
             .join(" | ")
     }
 
+    fn make_template_section(ops: Vec<StringOp>) -> TemplateSection {
+        TemplateSection::from_ops(ops)
+    }
+
+    fn hash_ops(ops: &[StringOp]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        ops.hash(&mut hasher);
+        hasher.finish()
+    }
+
     /* -------- helper: detect plain single-block templates ------------- */
 
     /// Detects and parses templates that consist of exactly one `{ ... }` block
@@ -993,7 +1014,7 @@ impl MultiTemplate {
 
         // Safe to treat as single template block.
         let (ops, dbg_flag) = parser::parse_template(template)?;
-        let sections = vec![TemplateSection::Template(ops)];
+        let sections = vec![Self::make_template_section(ops)];
         Ok(Some(Self::new(template.to_string(), sections, dbg_flag)))
     }
 }


### PR DESCRIPTION
| Benchmark | Before | After | Approx. Change |
|---|---:|---:|---:|
| `template_execution/single_block_upper_small` | 238 ns | 153 ns | 36% faster |
| `template_execution/split_join_small` | 1.92 us | 218 ns | 89% faster |
| `template_execution/split_join_large` | 1.60 ms | 149 us | 91% faster |
| `template_execution/multi_section_format` | 412 ns | 444 ns | 8% slower |
| `template_execution/repeated_split_sections` | 1.57 us | 1.46 us | 7% faster |
| `template_execution/filter_sort` | 7.79 us | 6.37 us | 18% faster |
| `template_execution/map_upper` | 3.75 us | 2.16 us | 42% faster |
| `template_execution/map_trim_upper_large` | 1.65 ms | 1.03 ms | 38% faster |
| `template_execution/complex_nested` | 10.36 us | 8.42 us | 19% faster |
| `structured_inputs/format_with_inputs` | 2.34 us | 1.38 us | 41% faster |

| Benchmark | Before | After | Approx. Change |
|---|---:|---:|---:|
| `Single: split` | 2.98 us | 215 ns | 93% faster |
| `Single: filter` | 9.09 us | 5.97 us | 34% faster |
| `Multi: split + join` | 2.72 us | 451 ns | 83% faster |
| `Multi: split + filter + join` | 7.27 us | 5.94 us | 18% faster |
| `Map: split + map(upper) + join` | 4.60 us | 2.90 us | 37% faster |
| `Map: split + map(replace) + join` | 14.61 us | 11.20 us | 23% faster |
| `Complex: split + map(split+join) + join` | 12.04 us | 7.80 us | 35% faster |
| `Complex: split + map(replace+upper)` | 23.77 us | 15.12 us | 36% faster |

