### PR TITLE
String pipeline rich return

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,53 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Rich Rendering
+
+Use the rich rendering path when you need both the final rendered string and the
+exact output produced by each template section.
+
+```rust
+use string_pipeline::Template;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let template = Template::parse("Preview {upper} ({lower})")?;
+    let result = template.format_rich("MiXeD")?;
+
+    assert_eq!(result.rendered(), "Preview MIXED (mixed)");
+    assert_eq!(result.template_output(0), Some("MIXED"));
+    assert_eq!(result.template_output(1), Some("mixed"));
+
+    let first = &result.template_outputs()[0];
+    assert_eq!(first.template_position(), 0);
+    assert_eq!(first.overall_position(), 1);
+    assert_eq!(first.as_str(result.rendered()), "MIXED");
+
+    Ok(())
+}
+```
+
+For structured templates, `format_with_inputs_rich()` exposes the per-section
+joined output after applying the same input and separator rules as
+`format_with_inputs()`.
+
+```rust
+use string_pipeline::Template;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let template = Template::parse("User: {upper} | File: {lower}")?;
+    let result = template.format_with_inputs_rich(
+        &[&["john doe", "jane smith"], &["README.MD"]],
+        &[" / ", " "],
+    )?;
+
+    assert_eq!(result.rendered(), "User: JOHN DOE / JANE SMITH | File: readme.md");
+    assert_eq!(result.template_output(0), Some("JOHN DOE / JANE SMITH"));
+    assert_eq!(result.template_output(1), Some("readme.md"));
+
+    Ok(())
+}
+```
+
 ### CLI (companion)
 
 Use the CLI to test the same templates externally.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ HELLO-WORLD
 
 API docs: <https://docs.rs/string_pipeline>
 
+## Deprecations
+
+Use `Template` as the public Rust type in new code.
+
+`MultiTemplate` is retained only as a compatibility name in the current release
+line and is planned for removal in the next major release.
+
 ## Development
 
 ```bash

--- a/docs/debug-system.md
+++ b/docs/debug-system.md
@@ -17,7 +17,7 @@ This document describes how debug output works in `string_pipeline`.
 Debug mode shows:
 
 - template/session boundaries
-- section-level processing for multi-template input
+- section-level processing for templates with literal text
 - cache events (`FAST SPLIT`, `CACHE HIT`, `CACHE MISS`)
 - per-operation input/result/timing
 - `map` item processing and sub-pipeline steps
@@ -157,7 +157,7 @@ string-pipeline -d '{split:,:..|map:{split: :..|join:-}}' 'hello world,foo bar'
 
 Use item-level traces to verify each sub-pipeline result.
 
-### Check cache reuse in multi-template input
+### Check cache reuse in templates with literal text
 
 ```bash
 string-pipeline -d 'A:{split:,:0|upper} B:{split:,:1|upper} C:{split:,:0|upper}' 'x,y,z'

--- a/docs/template-system.md
+++ b/docs/template-system.md
@@ -7,7 +7,7 @@ This document describes the template syntax used by `string_pipeline`.
 - [Quick Start](#quick-start)
 - [Template Syntax](#template-syntax)
 - [Evaluation Rules](#evaluation-rules)
-- [Multi-template Strings](#multi-template-strings)
+- [Templates With Literal Text](#templates-with-literal-text)
 - [Rich Rendering](#rich-rendering)
 - [Operation Reference](#operation-reference)
 - [Range Specifications](#range-specifications)
@@ -47,8 +47,7 @@ Notes:
 
 - `{}` is valid and returns the input unchanged.
 - Operations are evaluated from left to right.
-- A template can contain either only a template block (`{...}`) or literal text with one or more blocks (multi-template
-mode).
+- A template can contain either only a template block (`{...}`) or literal text with one or more blocks.
 
 ### Shorthand syntax
 
@@ -92,9 +91,10 @@ most recent `split` or `join` operation in that pipeline.
 
 Use an explicit `join` as the final step when output format must be fixed.
 
-## Multi-template Strings
+## Templates With Literal Text
 
-A multi-template combines literal text and one or more template sections.
+A template with literal text combines static content and one or more template
+sections.
 
 ```text
 User: {split:,:0} Score: {split:,:1}
@@ -180,6 +180,13 @@ assert_eq!(result.template_output(1), Some("readme.md"));
 
 In this mode, each rich template output is the fully joined output inserted for
 that section after applying the same rules as `format_with_inputs()`.
+
+## Deprecations
+
+Use `Template` as the public type name in new code.
+
+`MultiTemplate` is retained only as a compatibility name in the current
+release line and is planned for removal in the next major release.
 
 ## Operation Reference
 

--- a/docs/template-system.md
+++ b/docs/template-system.md
@@ -8,6 +8,7 @@ This document describes the template syntax used by `string_pipeline`.
 - [Template Syntax](#template-syntax)
 - [Evaluation Rules](#evaluation-rules)
 - [Multi-template Strings](#multi-template-strings)
+- [Rich Rendering](#rich-rendering)
 - [Operation Reference](#operation-reference)
 - [Range Specifications](#range-specifications)
 - [Escaping Rules](#escaping-rules)
@@ -120,6 +121,65 @@ Within one `format()` call, repeated template sections with the same operation s
 string-pipeline "First: {split:,:0} Again: {split:,:0}" "apple,banana,cherry"
 # First: apple Again: apple
 ```
+
+## Rich Rendering
+
+The standard rendering path returns only the final string. The rich rendering
+path keeps that final string and also exposes the output produced by each
+template section.
+
+This is useful when the caller needs to treat template substitutions
+differently from literal text, for example to post-process only the dynamic
+parts before passing the rendered result to another system.
+
+### Single-input rendering
+
+Use `format_rich()` to format one input while preserving per-section outputs.
+
+```rust
+use string_pipeline::Template;
+
+let template = Template::parse("Preview {upper} ({lower})").unwrap();
+let result = template.format_rich("MiXeD").unwrap();
+
+assert_eq!(result.rendered(), "Preview MIXED (mixed)");
+assert_eq!(result.template_output(0), Some("MIXED"));
+assert_eq!(result.template_output(1), Some("mixed"));
+```
+
+Each `TemplateOutput` also exposes metadata:
+
+- `template_position()`: position among template sections only
+- `overall_position()`: position among all sections, including literals
+- `rendered_range()`: byte range inside the final rendered string
+- `as_str(result.rendered())`: borrowed view of that section output
+
+The per-section outputs are stored as ranges into the final rendered string, so
+the rich path does not retain a second owned string per template section.
+
+### Structured-input rendering
+
+Use `format_with_inputs_rich()` when each template section receives its own
+input slice and separator.
+
+```rust
+use string_pipeline::Template;
+
+let template = Template::parse("User: {upper} | File: {lower}").unwrap();
+let result = template
+    .format_with_inputs_rich(
+        &[&["john doe", "jane smith"], &["README.MD"]],
+        &[" / ", " "],
+    )
+    .unwrap();
+
+assert_eq!(result.rendered(), "User: JOHN DOE / JANE SMITH | File: readme.md");
+assert_eq!(result.template_output(0), Some("JOHN DOE / JANE SMITH"));
+assert_eq!(result.template_output(1), Some("readme.md"));
+```
+
+In this mode, each rich template output is the fully joined output inserted for
+that section after applying the same rules as `format_with_inputs()`.
 
 ## Operation Reference
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,8 @@
 //! let result = template.format_rich("MiXeD").unwrap();
 //!
 //! assert_eq!(result.rendered, "asd MIXED bsd mixed");
-//! assert_eq!(result.template_outputs[0].output, "MIXED");
-//! assert_eq!(result.template_outputs[1].output, "mixed");
+//! assert_eq!(result.template_output(0), Some("MIXED"));
+//! assert_eq!(result.template_output(1), Some("mixed"));
 //! ```
 //!
 //! ## Error Handling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,7 @@
 
 mod pipeline;
 
+#[allow(deprecated)]
 pub use pipeline::{
     MultiTemplate, RichFormatResult, SectionInfo, SectionType, Template, TemplateOutput,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,21 +85,21 @@
 //! assert_eq!(result, "a,b,c");
 //! ```
 //!
-//! ## Multi-Template Support
+//! ## Templates With Literal Text
 //!
-//! Beyond simple templates, the library supports **multi-templates** that combine literal text
-//! with multiple template sections, featuring automatic caching for performance:
+//! Mixed literal/template strings support automatic caching for repeated
+//! sections within one render call:
 //!
 //! ```rust
-//! use string_pipeline::MultiTemplate;
+//! use string_pipeline::Template;
 //!
 //! // Combine literal text with template operations
-//! let template = MultiTemplate::parse("Name: {split: :0} Age: {split: :1}").unwrap();
+//! let template = Template::parse("Name: {split: :0} Age: {split: :1}").unwrap();
 //! let result = template.format("John 25").unwrap();
 //! assert_eq!(result, "Name: John Age: 25");
 //!
 //! // Automatic caching: split operation performed only once
-//! let template = MultiTemplate::parse("First: {split:,:0} Second: {split:,:1}").unwrap();
+//! let template = Template::parse("First: {split:,:0} Second: {split:,:1}").unwrap();
 //! let result = template.format("apple,banana").unwrap();
 //! assert_eq!(result, "First: apple Second: banana");
 //! ```
@@ -308,8 +308,15 @@
 //! }
 //! ```
 //!
+//! ## Compatibility
+//!
+//! Use [`Template`] as the public type name in new code.
+//!
+//! `MultiTemplate` is retained only as a compatibility name in the current
+//! release line and is planned for removal in the next major release.
+//!
 //! For complete documentation including all operations, advanced features, and debugging techniques,
-//! see the [`Template`] and [`MultiTemplate`] documentation and the comprehensive guides in the `docs/` directory.
+//! see the [`Template`] documentation and the comprehensive guides in the `docs/` directory.
 
 mod pipeline;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,22 @@
 //! assert_eq!(sections.len(), 2); // Two template sections: {strip_ansi|lower} and {}
 //! ```
 //!
+//! ## Rich Formatting Results
+//!
+//! Use `format_rich()` when you need both the final rendered string and the
+//! individual result of each template section.
+//!
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("asd {upper} bsd {lower}").unwrap();
+//! let result = template.format_rich("MiXeD").unwrap();
+//!
+//! assert_eq!(result.rendered, "asd MIXED bsd mixed");
+//! assert_eq!(result.template_outputs[0].output, "MIXED");
+//! assert_eq!(result.template_outputs[1].output, "mixed");
+//! ```
+//!
 //! ## Error Handling
 //!
 //! All operations return `Result<String, String>` for comprehensive error handling:
@@ -260,4 +276,6 @@
 
 mod pipeline;
 
-pub use pipeline::{MultiTemplate, SectionInfo, SectionType, Template};
+pub use pipeline::{
+    MultiTemplate, RichFormatResult, SectionInfo, SectionType, Template, TemplateOutput,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,46 @@
 //! let template = Template::parse("asd {upper} bsd {lower}").unwrap();
 //! let result = template.format_rich("MiXeD").unwrap();
 //!
-//! assert_eq!(result.rendered, "asd MIXED bsd mixed");
+//! assert_eq!(result.rendered(), "asd MIXED bsd mixed");
 //! assert_eq!(result.template_output(0), Some("MIXED"));
 //! assert_eq!(result.template_output(1), Some("mixed"));
+//! ```
+//!
+//! The rich result stores per-template outputs as ranges into the final
+//! rendered string. Use `template_output()` for direct indexed access or
+//! `template_outputs()` plus `TemplateOutput::as_str()` when you also need
+//! section positions.
+//!
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("User: {upper}").unwrap();
+//! let result = template.format_rich("john").unwrap();
+//! let output = &result.template_outputs()[0];
+//!
+//! assert_eq!(output.template_position(), 0);
+//! assert_eq!(output.overall_position(), 1);
+//! assert_eq!(output.as_str(result.rendered()), "JOHN");
+//! ```
+//!
+//! Use `format_with_inputs_rich()` for structured templates when each template
+//! section receives its own input slice and separator.
+//!
+//! ```rust
+//! use string_pipeline::Template;
+//!
+//! let template = Template::parse("Users: {upper} | Files: {lower}").unwrap();
+//! let result = template.format_with_inputs_rich(
+//!     &[&["john doe", "jane smith"], &["FILE1.TXT", "FILE2.TXT"]],
+//!     &[" / ", ","],
+//! ).unwrap();
+//!
+//! assert_eq!(
+//!     result.rendered(),
+//!     "Users: JOHN DOE / JANE SMITH | Files: file1.txt,file2.txt"
+//! );
+//! assert_eq!(result.template_output(0), Some("JOHN DOE / JANE SMITH"));
+//! assert_eq!(result.template_output(1), Some("file1.txt,file2.txt"));
 //! ```
 //!
 //! ## Error Handling

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{CommandFactory, Parser};
 use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
-use string_pipeline::MultiTemplate;
+use string_pipeline::Template;
 
 #[derive(Parser)]
 #[command(
@@ -235,7 +235,7 @@ fn main() {
     });
 
     // Parse template and handle debug mode from both template prefix and CLI flag
-    let template = MultiTemplate::parse_with_debug(&config.template, None).unwrap_or_else(|e| {
+    let template = Template::parse_with_debug(&config.template, None).unwrap_or_else(|e| {
         eprintln!("Error parsing template: {e}");
         std::process::exit(1);
     });

--- a/src/pipeline/debug.rs
+++ b/src/pipeline/debug.rs
@@ -46,7 +46,7 @@ impl DebugTracer {
         }
     }
 
-    /// Logs the start of a session (template or multi-template processing).
+    /// Logs the start of a session (template or template processing).
     ///
     /// This marks the beginning of a complete processing session, showing
     /// the session type, template string, input data, and optional additional information.
@@ -310,9 +310,9 @@ impl DebugTracer {
         self.separator();
     }
 
-    /// Logs section processing information for multi-template operations.
+    /// Logs section processing information for template operations.
     ///
-    /// This shows progress through different sections of a multi-template,
+    /// This shows progress through different sections of a template,
     /// including section type and content information.
     ///
     /// # Arguments

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -52,7 +52,9 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-pub use crate::pipeline::template::{MultiTemplate, SectionInfo, SectionType, Template};
+pub use crate::pipeline::template::{
+    MultiTemplate, RichFormatResult, SectionInfo, SectionType, Template, TemplateOutput,
+};
 pub use debug::DebugTracer;
 
 /* ------------------------------------------------------------------------ */

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -12,7 +12,7 @@
 //! The pipeline system consists of several key components:
 //!
 //! - **Operations**: The [`StringOp`] enum defines all available transformations
-//! - **Templates**: The [`MultiTemplate`] type provides template-based processing
+//! - **Templates**: The [`Template`] type provides template-based processing
 //! - **Execution Engine**: The [`apply_ops_internal`] function processes operation sequences
 //! - **Caching**: Global caches for regex compilation and string splitting
 //! - **Debug Support**: Comprehensive tracing via [`DebugTracer`]

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -52,6 +52,7 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+#[allow(deprecated)]
 pub use crate::pipeline::template::{
     MultiTemplate, RichFormatResult, SectionInfo, SectionType, Template, TemplateOutput,
 };

--- a/src/pipeline/parser.rs
+++ b/src/pipeline/parser.rs
@@ -95,14 +95,14 @@ pub fn parse_template(template: &str) -> Result<(Vec<StringOp>, bool), String> {
     Ok((ops, debug))
 }
 
-/// Parses a multi-template string containing mixed literal text and template sections.
+/// Parses a template string containing mixed literal text and template sections.
 ///
 /// This function processes strings that contain both literal text and template operations,
 /// creating a sequence of sections that can be processed with caching support.
 ///
 /// # Arguments
 ///
-/// * `template` - The multi-template string to parse
+/// * `template` - The template string to parse
 ///
 /// # Returns
 ///
@@ -112,7 +112,7 @@ pub fn parse_template(template: &str) -> Result<(Vec<StringOp>, bool), String> {
 /// # Examples
 ///
 /// ```rust
-/// // This is an internal function used by MultiTemplate::parse()
+/// // This is an internal function used by Template::parse()
 /// // let (sections, debug) = parse_multi_template("Hello {upper} world").unwrap();
 /// // assert_eq!(sections.len(), 3); // "Hello ", upper operation, " world"
 /// ```
@@ -184,7 +184,7 @@ pub fn parse_multi_template(template: &str) -> Result<(Vec<TemplateSection>, boo
                 let full_template = format!("{{{template_content}}}");
                 let (ops, section_debug) = parse_template(&full_template)?;
                 if section_debug {
-                    debug = true; // If any section has debug enabled, enable for the whole multi-template
+                    debug = true; // If any section has debug enabled, enable for the whole template
                 }
 
                 sections.push(TemplateSection::from_ops(ops));

--- a/src/pipeline/parser.rs
+++ b/src/pipeline/parser.rs
@@ -113,10 +113,10 @@ pub fn parse_template(template: &str) -> Result<(Vec<StringOp>, bool), String> {
 ///
 /// ```rust
 /// // This is an internal function used by Template::parse()
-/// // let (sections, debug) = parse_multi_template("Hello {upper} world").unwrap();
+/// // let (sections, debug) = parse_template_sections("Hello {upper} world").unwrap();
 /// // assert_eq!(sections.len(), 3); // "Hello ", upper operation, " world"
 /// ```
-pub fn parse_multi_template(template: &str) -> Result<(Vec<TemplateSection>, bool), String> {
+pub fn parse_template_sections(template: &str) -> Result<(Vec<TemplateSection>, bool), String> {
     let mut sections = Vec::new();
     let mut current_literal = String::new();
     let mut chars = template.chars().peekable();
@@ -203,6 +203,16 @@ pub fn parse_multi_template(template: &str) -> Result<(Vec<TemplateSection>, boo
     }
 
     Ok((sections, debug))
+}
+
+/// Deprecated compatibility wrapper for [`parse_template_sections`].
+#[allow(dead_code)]
+#[deprecated(
+    since = "0.14.0",
+    note = "use `parse_template_sections` instead; `parse_multi_template` will be removed in the next major release"
+)]
+pub fn parse_multi_template(template: &str) -> Result<(Vec<TemplateSection>, bool), String> {
+    parse_template_sections(template)
 }
 
 /// Parses a single operation from a parse tree node.

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -48,6 +48,7 @@
 use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
+use std::ops::Range;
 
 use crate::pipeline::get_cached_split;
 use crate::pipeline::{DebugTracer, RangeSpec, StringOp, apply_ops_internal, apply_range, parser}; // ← use global split cache
@@ -271,7 +272,7 @@ pub struct SectionInfo {
 ///
 /// assert_eq!(result.template_outputs[0].template_position, 0);
 /// assert_eq!(result.template_outputs[0].overall_position, 1);
-/// assert_eq!(result.template_outputs[0].output, "MIXED");
+/// assert_eq!(result.template_output(0), Some("MIXED"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TemplateOutput {
@@ -279,8 +280,15 @@ pub struct TemplateOutput {
     pub template_position: usize,
     /// Position among all sections, including literals.
     pub overall_position: usize,
-    /// Exact rendered output inserted for this template section.
-    pub output: String,
+    /// Byte range within [`RichFormatResult::rendered`] for this template section.
+    pub rendered_range: Range<usize>,
+}
+
+impl TemplateOutput {
+    /// Borrow this section's rendered output from the full rendered string.
+    pub fn as_str<'a>(&self, rendered: &'a str) -> &'a str {
+        &rendered[self.rendered_range.clone()]
+    }
 }
 
 /// Rich formatting result containing the final rendered string and per-template outputs.
@@ -298,8 +306,8 @@ pub struct TemplateOutput {
 ///
 /// assert_eq!(result.rendered, "asd MIXED bsd mixed");
 /// assert_eq!(result.template_outputs.len(), 2);
-/// assert_eq!(result.template_outputs[0].output, "MIXED");
-/// assert_eq!(result.template_outputs[1].output, "mixed");
+/// assert_eq!(result.template_output(0), Some("MIXED"));
+/// assert_eq!(result.template_output(1), Some("mixed"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RichFormatResult {
@@ -307,6 +315,15 @@ pub struct RichFormatResult {
     pub rendered: String,
     /// Outputs for each template section in left-to-right order.
     pub template_outputs: Vec<TemplateOutput>,
+}
+
+impl RichFormatResult {
+    /// Borrow the output of the template section at `index`.
+    pub fn template_output(&self, index: usize) -> Option<&str> {
+        self.template_outputs
+            .get(index)
+            .map(|output| output.as_str(&self.rendered))
+    }
 }
 
 /* ---------- per-format call cache (operation results only) -------------- */
@@ -366,13 +383,15 @@ impl RenderBuffer {
         overall_position: usize,
         output: String,
     ) {
+        let start = self.rendered.len();
         self.rendered.push_str(&output);
+        let end = self.rendered.len();
 
         if let Some(template_outputs) = &mut self.template_outputs {
             template_outputs.push(TemplateOutput {
                 template_position,
                 overall_position,
-                output,
+                rendered_range: start..end,
             });
         }
     }
@@ -572,8 +591,8 @@ impl MultiTemplate {
     /// let result = template.format_rich("MiXeD").unwrap();
     ///
     /// assert_eq!(result.rendered, "asd MIXED bsd mixed");
-    /// assert_eq!(result.template_outputs[0].output, "MIXED");
-    /// assert_eq!(result.template_outputs[1].output, "mixed");
+    /// assert_eq!(result.template_output(0), Some("MIXED"));
+    /// assert_eq!(result.template_output(1), Some("mixed"));
     /// ```
     pub fn format_rich(&self, input: &str) -> Result<RichFormatResult, String> {
         self.render_single_input(input, true)

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -275,6 +275,7 @@ pub struct SectionInfo {
 /// assert_eq!(result.template_output(0), Some("MIXED"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct TemplateOutput {
     /// Position among template sections only.
     pub template_position: usize,
@@ -285,6 +286,21 @@ pub struct TemplateOutput {
 }
 
 impl TemplateOutput {
+    /// Position among template sections only.
+    pub fn template_position(&self) -> usize {
+        self.template_position
+    }
+
+    /// Position among all sections, including literals.
+    pub fn overall_position(&self) -> usize {
+        self.overall_position
+    }
+
+    /// Byte range within [`RichFormatResult::rendered`] for this template section.
+    pub fn rendered_range(&self) -> Range<usize> {
+        self.rendered_range.clone()
+    }
+
     /// Borrow this section's rendered output from the full rendered string.
     pub fn as_str<'a>(&self, rendered: &'a str) -> &'a str {
         &rendered[self.rendered_range.clone()]
@@ -310,6 +326,7 @@ impl TemplateOutput {
 /// assert_eq!(result.template_output(1), Some("mixed"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RichFormatResult {
     /// Final rendered output, identical to what `format()` would return.
     pub rendered: String,
@@ -318,6 +335,16 @@ pub struct RichFormatResult {
 }
 
 impl RichFormatResult {
+    /// Final rendered output, identical to what `format()` would return.
+    pub fn rendered(&self) -> &str {
+        &self.rendered
+    }
+
+    /// Outputs for each template section in left-to-right order.
+    pub fn template_outputs(&self) -> &[TemplateOutput] {
+        &self.template_outputs
+    }
+
     /// Borrow the output of the template section at `index`.
     pub fn template_output(&self, index: usize) -> Option<&str> {
         self.template_outputs

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -262,6 +262,10 @@ pub struct SectionInfo {
 /// This captures the exact string produced for one template section during
 /// formatting, along with both its template-only and overall section positions.
 ///
+/// The output itself is represented as a byte range into
+/// [`RichFormatResult::rendered`], which avoids retaining a second owned string
+/// for every template section collected through the rich rendering path.
+///
 /// # Examples
 ///
 /// ```rust
@@ -270,8 +274,8 @@ pub struct SectionInfo {
 /// let template = Template::parse("A: {upper} B: {lower}").unwrap();
 /// let result = template.format_rich("MiXeD").unwrap();
 ///
-/// assert_eq!(result.template_outputs[0].template_position, 0);
-/// assert_eq!(result.template_outputs[0].overall_position, 1);
+/// assert_eq!(result.template_outputs()[0].template_position(), 0);
+/// assert_eq!(result.template_outputs()[0].overall_position(), 1);
 /// assert_eq!(result.template_output(0), Some("MIXED"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -302,6 +306,9 @@ impl TemplateOutput {
     }
 
     /// Borrow this section's rendered output from the full rendered string.
+    ///
+    /// This is the zero-allocation way to inspect a single template section
+    /// once you have a [`RichFormatResult`].
     pub fn as_str<'a>(&self, rendered: &'a str) -> &'a str {
         &rendered[self.rendered_range.clone()]
     }
@@ -312,6 +319,11 @@ impl TemplateOutput {
 /// This type preserves the existing final string output while exposing the
 /// individual rendered results for each template section.
 ///
+/// `rendered` is identical to the output of [`MultiTemplate::format`].
+/// `template_outputs` contains metadata for each template section in left-to-right
+/// order, and section strings can be accessed with [`RichFormatResult::template_output`]
+/// or [`TemplateOutput::as_str`].
+///
 /// # Examples
 ///
 /// ```rust
@@ -320,8 +332,8 @@ impl TemplateOutput {
 /// let template = Template::parse("asd {upper} bsd {lower}").unwrap();
 /// let result = template.format_rich("MiXeD").unwrap();
 ///
-/// assert_eq!(result.rendered, "asd MIXED bsd mixed");
-/// assert_eq!(result.template_outputs.len(), 2);
+/// assert_eq!(result.rendered(), "asd MIXED bsd mixed");
+/// assert_eq!(result.template_outputs().len(), 2);
 /// assert_eq!(result.template_output(0), Some("MIXED"));
 /// assert_eq!(result.template_output(1), Some("mixed"));
 /// ```
@@ -340,12 +352,17 @@ impl RichFormatResult {
         &self.rendered
     }
 
-    /// Outputs for each template section in left-to-right order.
+    /// Metadata for each template section in left-to-right order.
+    ///
+    /// Use [`RichFormatResult::template_output`] or [`TemplateOutput::as_str`]
+    /// to borrow the corresponding rendered section text.
     pub fn template_outputs(&self) -> &[TemplateOutput] {
         &self.template_outputs
     }
 
     /// Borrow the output of the template section at `index`.
+    ///
+    /// Returns `None` when the index is out of bounds.
     pub fn template_output(&self, index: usize) -> Option<&str> {
         self.template_outputs
             .get(index)
@@ -609,6 +626,9 @@ impl MultiTemplate {
     /// `template_outputs` captures the exact text inserted for each template
     /// section in left-to-right order.
     ///
+    /// The returned section metadata points into the final rendered string, so
+    /// the rich path avoids storing duplicate owned strings for each section.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -617,7 +637,7 @@ impl MultiTemplate {
     /// let template = Template::parse("asd {upper} bsd {lower}").unwrap();
     /// let result = template.format_rich("MiXeD").unwrap();
     ///
-    /// assert_eq!(result.rendered, "asd MIXED bsd mixed");
+    /// assert_eq!(result.rendered(), "asd MIXED bsd mixed");
     /// assert_eq!(result.template_output(0), Some("MIXED"));
     /// assert_eq!(result.template_output(1), Some("mixed"));
     /// ```
@@ -830,6 +850,28 @@ impl MultiTemplate {
     /// `template_outputs` contains the exact joined output inserted for each
     /// template section after applying the same input and separator rules as
     /// [`MultiTemplate::format_with_inputs`].
+    ///
+    /// This is useful when callers need the final rendered string and also need
+    /// to inspect or post-process the dynamic output of each template section
+    /// independently.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use string_pipeline::Template;
+    ///
+    /// let template = Template::parse("User: {upper} | File: {lower}").unwrap();
+    /// let result = template
+    ///     .format_with_inputs_rich(
+    ///         &[&["john doe", "jane smith"], &["README.MD"]],
+    ///         &[" / ", " "],
+    ///     )
+    ///     .unwrap();
+    ///
+    /// assert_eq!(result.rendered(), "User: JOHN DOE / JANE SMITH | File: readme.md");
+    /// assert_eq!(result.template_output(0), Some("JOHN DOE / JANE SMITH"));
+    /// assert_eq!(result.template_output(1), Some("readme.md"));
+    /// ```
     pub fn format_with_inputs_rich(
         &self,
         inputs: &[&[&str]],

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -256,6 +256,59 @@ pub struct SectionInfo {
     pub operations: Option<Vec<StringOp>>,
 }
 
+/// Rich output for a single template section.
+///
+/// This captures the exact string produced for one template section during
+/// formatting, along with both its template-only and overall section positions.
+///
+/// # Examples
+///
+/// ```rust
+/// use string_pipeline::Template;
+///
+/// let template = Template::parse("A: {upper} B: {lower}").unwrap();
+/// let result = template.format_rich("MiXeD").unwrap();
+///
+/// assert_eq!(result.template_outputs[0].template_position, 0);
+/// assert_eq!(result.template_outputs[0].overall_position, 1);
+/// assert_eq!(result.template_outputs[0].output, "MIXED");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateOutput {
+    /// Position among template sections only.
+    pub template_position: usize,
+    /// Position among all sections, including literals.
+    pub overall_position: usize,
+    /// Exact rendered output inserted for this template section.
+    pub output: String,
+}
+
+/// Rich formatting result containing the final rendered string and per-template outputs.
+///
+/// This type preserves the existing final string output while exposing the
+/// individual rendered results for each template section.
+///
+/// # Examples
+///
+/// ```rust
+/// use string_pipeline::Template;
+///
+/// let template = Template::parse("asd {upper} bsd {lower}").unwrap();
+/// let result = template.format_rich("MiXeD").unwrap();
+///
+/// assert_eq!(result.rendered, "asd MIXED bsd mixed");
+/// assert_eq!(result.template_outputs.len(), 2);
+/// assert_eq!(result.template_outputs[0].output, "MIXED");
+/// assert_eq!(result.template_outputs[1].output, "mixed");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RichFormatResult {
+    /// Final rendered output, identical to what `format()` would return.
+    pub rendered: String,
+    /// Outputs for each template section in left-to-right order.
+    pub template_outputs: Vec<TemplateOutput>,
+}
+
 /* ---------- per-format call cache (operation results only) -------------- */
 
 /// Per-template-instance cache for operation results.
@@ -277,7 +330,7 @@ impl TemplateCache {
 struct ExecutionContext<'a> {
     input_hash: &'a mut Option<u64>,
     cache: &'a mut TemplateCache,
-    dbg: &'a Option<&'a DebugTracer>,
+    dbg: Option<&'a DebugTracer>,
 }
 
 /// Cache key combining input hash and operation signature.
@@ -288,6 +341,52 @@ struct ExecutionContext<'a> {
 struct CacheKey {
     input_hash: u64,
     section_key: u64,
+}
+
+struct RenderBuffer {
+    rendered: String,
+    template_outputs: Option<Vec<TemplateOutput>>,
+}
+
+impl RenderBuffer {
+    fn new(rendered_capacity: usize, rich_capacity: Option<usize>) -> Self {
+        Self {
+            rendered: String::with_capacity(rendered_capacity),
+            template_outputs: rich_capacity.map(Vec::with_capacity),
+        }
+    }
+
+    fn push_literal(&mut self, text: &str) {
+        self.rendered.push_str(text);
+    }
+
+    fn push_template_output(
+        &mut self,
+        template_position: usize,
+        overall_position: usize,
+        output: String,
+    ) {
+        self.rendered.push_str(&output);
+
+        if let Some(template_outputs) = &mut self.template_outputs {
+            template_outputs.push(TemplateOutput {
+                template_position,
+                overall_position,
+                output,
+            });
+        }
+    }
+
+    fn into_rendered(self) -> String {
+        self.rendered
+    }
+
+    fn into_rich(self) -> RichFormatResult {
+        RichFormatResult {
+            rendered: self.rendered,
+            template_outputs: self.template_outputs.unwrap_or_default(),
+        }
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -453,104 +552,32 @@ impl MultiTemplate {
     /// assert_eq!(result, "Items: apple | banana | cherry");
     /// ```
     pub fn format(&self, input: &str) -> Result<String, String> {
-        use std::time::Instant;
+        self.render_single_input(input, false)
+            .map(RenderBuffer::into_rendered)
+    }
 
-        let mut cache = TemplateCache::new();
-        let mut result = String::with_capacity(self.estimate_output_capacity(input));
-        let mut input_hash = None;
-
-        /* -------- optional debug session -------------------------------- */
-
-        let start_time = if self.debug {
-            Some(Instant::now())
-        } else {
-            None
-        };
-
-        if self.debug {
-            let tracer = DebugTracer::new(true);
-            let info = format!(
-                "{} sections (literal: {}, template: {})",
-                self.sections.len(),
-                self.sections.len() - self.template_section_count(),
-                self.template_section_count()
-            );
-            tracer.session_start("MULTI-TEMPLATE", &self.raw, input, Some(&info));
-
-            for (idx, (section, plan)) in self
-                .sections
-                .iter()
-                .zip(self.compiled_sections.iter())
-                .enumerate()
-            {
-                match (section, plan) {
-                    (TemplateSection::Literal(text), CompiledSectionPlan::Literal) => {
-                        let preview = if text.trim().is_empty() && text.len() <= 2 {
-                            "whitespace".to_string()
-                        } else if text.len() <= 20 {
-                            format!("'{text}'")
-                        } else {
-                            format!("'{}...' ({} chars)", &text[..15], text.len())
-                        };
-                        tracer.section(idx + 1, self.sections.len(), "literal", &preview);
-                        result.push_str(text);
-                        if idx + 1 < self.sections.len() {
-                            tracer.separator();
-                        }
-                    }
-                    (
-                        TemplateSection::Template { ops, .. },
-                        CompiledSectionPlan::Template { exec, cache_key },
-                    ) => {
-                        let summary = Self::format_operations_summary(ops);
-                        tracer.section(idx + 1, self.sections.len(), "template", &summary);
-                        let out = self.execute_template_section(
-                            input,
-                            ops,
-                            exec,
-                            *cache_key,
-                            ExecutionContext {
-                                input_hash: &mut input_hash,
-                                cache: &mut cache,
-                                dbg: &Some(&tracer),
-                            },
-                        )?;
-                        result.push_str(&out);
-                    }
-                    _ => unreachable!("compiled section plan must match template sections"),
-                }
-            }
-
-            tracer.session_end("MULTI-TEMPLATE", &result, start_time.unwrap().elapsed());
-        } else {
-            for (section, plan) in self.sections.iter().zip(self.compiled_sections.iter()) {
-                match (section, plan) {
-                    (TemplateSection::Literal(text), CompiledSectionPlan::Literal) => {
-                        result.push_str(text)
-                    }
-                    (
-                        TemplateSection::Template { ops, .. },
-                        CompiledSectionPlan::Template { exec, cache_key },
-                    ) => {
-                        let out = self.execute_template_section(
-                            input,
-                            ops,
-                            exec,
-                            *cache_key,
-                            ExecutionContext {
-                                input_hash: &mut input_hash,
-                                cache: &mut cache,
-                                dbg: &None,
-                            },
-                        )?;
-                        result.push_str(&out);
-                    }
-                    _ => unreachable!("compiled section plan must match template sections"),
-                }
-            }
-        }
-
-        Ok(result)
+    /// Apply the template to input data, returning both the final string and
+    /// each rendered template section result.
+    ///
+    /// `rendered` is identical to the output of [`MultiTemplate::format`], while
+    /// `template_outputs` captures the exact text inserted for each template
+    /// section in left-to-right order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use string_pipeline::Template;
+    ///
+    /// let template = Template::parse("asd {upper} bsd {lower}").unwrap();
+    /// let result = template.format_rich("MiXeD").unwrap();
+    ///
+    /// assert_eq!(result.rendered, "asd MIXED bsd mixed");
+    /// assert_eq!(result.template_outputs[0].output, "MIXED");
+    /// assert_eq!(result.template_outputs[1].output, "mixed");
+    /// ```
+    pub fn format_rich(&self, input: &str) -> Result<RichFormatResult, String> {
+        self.render_single_input(input, true)
+            .map(RenderBuffer::into_rich)
     }
 
     /* -------- public helpers ------------------------------------------- */
@@ -747,104 +774,23 @@ impl MultiTemplate {
         inputs: &[&[&str]],
         separators: &[&str],
     ) -> Result<String, String> {
-        let template_sections_count = self.template_section_count();
+        self.render_structured_inputs(inputs, separators, false)
+            .map(RenderBuffer::into_rendered)
+    }
 
-        // Handle input/template count mismatches gracefully
-        let adjusted_inputs: Vec<&[&str]> = (0..template_sections_count)
-            .map(|i| {
-                if i < inputs.len() {
-                    inputs[i] // Use actual input
-                } else {
-                    &[] as &[&str] // Empty slice for missing inputs
-                }
-            })
-            .collect();
-
-        // Handle separator/template count mismatches gracefully
-        let adjusted_separators: Vec<&str> = (0..template_sections_count)
-            .map(|i| {
-                if i < separators.len() {
-                    separators[i] // Use actual separator
-                } else {
-                    " " // Default to space for missing separators
-                }
-            })
-            .collect();
-
-        let inputs = &adjusted_inputs;
-        let separators = &adjusted_separators;
-
-        let mut result = String::new();
-        let mut template_index = 0;
-        let mut cache = TemplateCache::new();
-
-        for (section, plan) in self.sections.iter().zip(self.compiled_sections.iter()) {
-            match (section, plan) {
-                (TemplateSection::Literal(text), CompiledSectionPlan::Literal) => {
-                    result.push_str(text);
-                }
-                (
-                    TemplateSection::Template { ops, .. },
-                    CompiledSectionPlan::Template { exec, cache_key },
-                ) => {
-                    if template_index >= inputs.len() {
-                        return Err("Internal error: template index out of bounds".to_string());
-                    }
-
-                    // Process each input individually, then join the results
-                    let section_inputs = inputs[template_index];
-                    let separator = separators[template_index];
-                    let output = match section_inputs.len() {
-                        0 => String::new(),
-                        1 => {
-                            let mut input_hasher = std::collections::hash_map::DefaultHasher::new();
-                            std::hash::Hash::hash(&section_inputs[0], &mut input_hasher);
-                            let mut input_hash = Some(input_hasher.finish());
-
-                            self.execute_template_section(
-                                section_inputs[0],
-                                ops,
-                                exec,
-                                *cache_key,
-                                ExecutionContext {
-                                    input_hash: &mut input_hash,
-                                    cache: &mut cache,
-                                    dbg: &None, // No debug tracing for structured processing
-                                },
-                            )?
-                        }
-                        _ => {
-                            let mut results = Vec::new();
-                            for input in section_inputs {
-                                let mut input_hasher =
-                                    std::collections::hash_map::DefaultHasher::new();
-                                std::hash::Hash::hash(&input, &mut input_hasher);
-                                let mut input_hash = Some(input_hasher.finish());
-
-                                let result = self.execute_template_section(
-                                    input,
-                                    ops,
-                                    exec,
-                                    *cache_key,
-                                    ExecutionContext {
-                                        input_hash: &mut input_hash,
-                                        cache: &mut cache,
-                                        dbg: &None, // No debug tracing for structured processing
-                                    },
-                                )?;
-                                results.push(result);
-                            }
-                            results.join(separator)
-                        }
-                    };
-                    result.push_str(&output);
-                    template_index += 1;
-                }
-                _ => unreachable!("compiled section plan must match template sections"),
-            }
-        }
-
-        Ok(result)
+    /// Format template with multiple inputs per template section, returning both
+    /// the final string and each per-section rendered output.
+    ///
+    /// `template_outputs` contains the exact joined output inserted for each
+    /// template section after applying the same input and separator rules as
+    /// [`MultiTemplate::format_with_inputs`].
+    pub fn format_with_inputs_rich(
+        &self,
+        inputs: &[&[&str]],
+        separators: &[&str],
+    ) -> Result<RichFormatResult, String> {
+        self.render_structured_inputs(inputs, separators, true)
+            .map(RenderBuffer::into_rich)
     }
 
     /// Get information about template sections for introspection.
@@ -948,6 +894,205 @@ impl MultiTemplate {
     /*  internal helpers                                                   */
     /* ------------------------------------------------------------------ */
 
+    fn render_single_input(&self, input: &str, collect_rich: bool) -> Result<RenderBuffer, String> {
+        use std::time::Instant;
+
+        let mut cache = TemplateCache::new();
+        let mut input_hash = None;
+        let start_time = self.debug.then(Instant::now);
+        let tracer = self.debug.then(|| DebugTracer::new(true));
+
+        if let Some(tracer) = tracer.as_ref() {
+            let info = format!(
+                "{} sections (literal: {}, template: {})",
+                self.sections.len(),
+                self.sections.len() - self.template_section_count(),
+                self.template_section_count()
+            );
+            tracer.session_start("MULTI-TEMPLATE", &self.raw, input, Some(&info));
+        }
+
+        let buffer = self.render_sections(
+            self.estimate_output_capacity(input),
+            collect_rich,
+            tracer.as_ref(),
+            |_, ops, exec, cache_key, dbg| {
+                self.execute_template_section(
+                    input,
+                    ops,
+                    exec,
+                    cache_key,
+                    ExecutionContext {
+                        input_hash: &mut input_hash,
+                        cache: &mut cache,
+                        dbg,
+                    },
+                )
+            },
+        )?;
+
+        if let (Some(tracer), Some(start_time)) = (tracer.as_ref(), start_time) {
+            tracer.session_end("MULTI-TEMPLATE", &buffer.rendered, start_time.elapsed());
+        }
+
+        Ok(buffer)
+    }
+
+    fn render_structured_inputs(
+        &self,
+        inputs: &[&[&str]],
+        separators: &[&str],
+        collect_rich: bool,
+    ) -> Result<RenderBuffer, String> {
+        let template_sections_count = self.template_section_count();
+
+        let adjusted_inputs: Vec<&[&str]> = (0..template_sections_count)
+            .map(|i| inputs.get(i).copied().unwrap_or(&[]))
+            .collect();
+        let adjusted_separators: Vec<&str> = (0..template_sections_count)
+            .map(|i| separators.get(i).copied().unwrap_or(" "))
+            .collect();
+
+        let mut cache = TemplateCache::new();
+
+        self.render_sections(
+            self.literal_output_capacity(),
+            collect_rich,
+            None,
+            |template_position, ops, exec, cache_key, _| {
+                self.execute_structured_template_section(
+                    adjusted_inputs[template_position],
+                    adjusted_separators[template_position],
+                    ops,
+                    exec,
+                    cache_key,
+                    &mut cache,
+                )
+            },
+        )
+    }
+
+    fn render_sections<F>(
+        &self,
+        rendered_capacity: usize,
+        collect_rich: bool,
+        tracer: Option<&DebugTracer>,
+        mut render_template_section: F,
+    ) -> Result<RenderBuffer, String>
+    where
+        F: FnMut(
+            usize,
+            &[StringOp],
+            &TemplateExecutionPlan,
+            u64,
+            Option<&DebugTracer>,
+        ) -> Result<String, String>,
+    {
+        let mut buffer = RenderBuffer::new(
+            rendered_capacity,
+            collect_rich.then_some(self.template_section_count()),
+        );
+        let mut template_position = 0;
+
+        for (overall_position, (section, plan)) in self
+            .sections
+            .iter()
+            .zip(self.compiled_sections.iter())
+            .enumerate()
+        {
+            match (section, plan) {
+                (TemplateSection::Literal(text), CompiledSectionPlan::Literal) => {
+                    if let Some(tracer) = tracer {
+                        let preview = Self::literal_preview(text);
+                        tracer.section(
+                            overall_position + 1,
+                            self.sections.len(),
+                            "literal",
+                            &preview,
+                        );
+                    }
+
+                    buffer.push_literal(text);
+
+                    if let Some(tracer) = tracer
+                        && overall_position + 1 < self.sections.len()
+                    {
+                        tracer.separator();
+                    }
+                }
+                (
+                    TemplateSection::Template { ops, .. },
+                    CompiledSectionPlan::Template { exec, cache_key },
+                ) => {
+                    if let Some(tracer) = tracer {
+                        let summary = Self::format_operations_summary(ops);
+                        tracer.section(
+                            overall_position + 1,
+                            self.sections.len(),
+                            "template",
+                            &summary,
+                        );
+                    }
+
+                    let output =
+                        render_template_section(template_position, ops, exec, *cache_key, tracer)?;
+                    buffer.push_template_output(template_position, overall_position, output);
+                    template_position += 1;
+                }
+                _ => unreachable!("compiled section plan must match template sections"),
+            }
+        }
+
+        Ok(buffer)
+    }
+
+    fn execute_structured_template_section(
+        &self,
+        section_inputs: &[&str],
+        separator: &str,
+        ops: &[StringOp],
+        exec: &TemplateExecutionPlan,
+        cache_key: u64,
+        cache: &mut TemplateCache,
+    ) -> Result<String, String> {
+        match section_inputs.len() {
+            0 => Ok(String::new()),
+            1 => {
+                let mut input_hash = Some(Self::hash_input(section_inputs[0]));
+                self.execute_template_section(
+                    section_inputs[0],
+                    ops,
+                    exec,
+                    cache_key,
+                    ExecutionContext {
+                        input_hash: &mut input_hash,
+                        cache,
+                        dbg: None,
+                    },
+                )
+            }
+            _ => {
+                let mut results = Vec::with_capacity(section_inputs.len());
+                for input in section_inputs {
+                    let mut input_hash = Some(Self::hash_input(input));
+                    let result = self.execute_template_section(
+                        input,
+                        ops,
+                        exec,
+                        cache_key,
+                        ExecutionContext {
+                            input_hash: &mut input_hash,
+                            cache,
+                            dbg: None,
+                        },
+                    )?;
+                    results.push(result);
+                }
+                Ok(results.join(separator))
+            }
+        }
+    }
+
     fn execute_template_section(
         &self,
         input: &str,
@@ -989,12 +1134,22 @@ impl MultiTemplate {
         }
     }
 
+    fn literal_preview(text: &str) -> String {
+        if text.trim().is_empty() && text.len() <= 2 {
+            "whitespace".to_string()
+        } else if text.len() <= 20 {
+            format!("'{text}'")
+        } else {
+            format!("'{}...' ({} chars)", &text[..15], text.len())
+        }
+    }
+
     fn execute_template_section_inner(
         &self,
         input: &str,
         ops: &[StringOp],
         kind: &TemplateExecutionKind,
-        dbg: &Option<&DebugTracer>,
+        dbg: Option<&DebugTracer>,
     ) -> Result<String, String> {
         match kind {
             TemplateExecutionKind::Passthrough => {
@@ -1104,6 +1259,16 @@ impl MultiTemplate {
             })
             .sum::<usize>()
             + input.len()
+    }
+
+    fn literal_output_capacity(&self) -> usize {
+        self.sections
+            .iter()
+            .map(|section| match section {
+                TemplateSection::Literal(text) => text.len(),
+                TemplateSection::Template { .. } => 0,
+            })
+            .sum()
     }
 
     fn hash_input(input: &str) -> u64 {

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -1,8 +1,9 @@
 //! Template engine for string transformation with mixed literal and operation sections.
 //!
-//! This module provides the `MultiTemplate` type, which supports templates containing
-//! both literal text and transformation sections. Templates can mix static content
-//! with dynamic string operations, enabling complex text processing patterns.
+//! This module provides the implementation behind the public `Template` API,
+//! supporting templates that contain both literal text and transformation
+//! sections. Templates can mix static content with dynamic string operations,
+//! enabling complex text processing patterns.
 //!
 //! # Template Syntax
 //!
@@ -55,14 +56,17 @@ use crate::pipeline::{DebugTracer, RangeSpec, StringOp, apply_ops_internal, appl
 use memchr::memchr_iter;
 
 /* ------------------------------------------------------------------------ */
-/*  MultiTemplate – the single implementation                               */
+/*  Template implementation                                                 */
 /* ------------------------------------------------------------------------ */
 
 /// A template engine supporting mixed literal text and string transformation operations.
 ///
-/// `MultiTemplate` can contain any combination of literal text sections and template
-/// sections that apply string operations to input data. This enables creating complex
-/// text formatting patterns while maintaining high performance through intelligent caching.
+/// Prefer using [`Template`] in public code.
+///
+/// This type can contain any combination of literal text sections and
+/// template sections that apply string operations to input data. This enables
+/// creating complex text formatting patterns while maintaining high performance
+/// through intelligent caching.
 ///
 /// # Template Structure
 ///
@@ -175,7 +179,7 @@ impl TemplateSection {
 ///
 /// Distinguishes between literal text sections and template operation sections
 /// when examining template structure programmatically. Used by introspection
-/// methods like [`MultiTemplate::get_section_info`] to provide detailed template analysis.
+/// methods like [`Template::get_section_info`] to provide detailed template analysis.
 ///
 /// # Examples
 ///
@@ -206,7 +210,7 @@ pub enum SectionType {
 /// Detailed information about a template section for introspection and debugging.
 ///
 /// Provides comprehensive metadata about each section in a template, including
-/// its type, position, and content. Used by [`MultiTemplate::get_section_info`]
+/// its type, position, and content. Used by [`Template::get_section_info`]
 /// to enable programmatic template analysis and debugging.
 ///
 /// This struct contains all necessary information to understand both the structure
@@ -319,7 +323,7 @@ impl TemplateOutput {
 /// This type preserves the existing final string output while exposing the
 /// individual rendered results for each template section.
 ///
-/// `rendered` is identical to the output of [`MultiTemplate::format`].
+/// `rendered` is identical to the output of [`Template::format`].
 /// `template_outputs` contains metadata for each template section in left-to-right
 /// order, and section strings can be accessed with [`RichFormatResult::template_output`]
 /// or [`TemplateOutput::as_str`].
@@ -453,7 +457,7 @@ impl RenderBuffer {
 }
 
 /* ------------------------------------------------------------------------ */
-/*  impl MultiTemplate                                                      */
+/*  impl Template internals                                                 */
 /* ------------------------------------------------------------------------ */
 
 impl MultiTemplate {
@@ -469,7 +473,7 @@ impl MultiTemplate {
 
     /* -------- constructors ---------------------------------------------- */
 
-    /// Parse a template string into a `MultiTemplate` instance.
+    /// Parse a template string into a `Template` instance.
     ///
     /// Parses template syntax containing literal text and `{operation}` blocks,
     /// with support for complex operation pipelines, debug information is suppressed.
@@ -480,7 +484,7 @@ impl MultiTemplate {
     ///
     /// # Returns
     ///
-    /// * `Ok(MultiTemplate)` - Successfully parsed template
+    /// * `Ok(Self)` - Successfully parsed template
     /// * `Err(String)` - Parse error description
     ///
     /// # Template Syntax
@@ -503,7 +507,7 @@ impl MultiTemplate {
     /// ```
     pub fn parse(template: &str) -> Result<Self, String> {
         // Fast-path: if the input is a *single* template block (no outer-level
-        // literal text) we can skip the multi-template scanner and directly
+        // literal text) we can skip the mixed-section scanner and directly
         // parse the operation list.
         if let Some(single) = Self::try_single_block(template)? {
             return Ok(single);
@@ -513,7 +517,7 @@ impl MultiTemplate {
         Ok(Self::new(template.to_string(), sections, false))
     }
 
-    /// Parse a template string into a `MultiTemplate` instance.
+    /// Parse a template string into a `Template` instance.
     ///
     /// Parses template syntax containing literal text and `{operation}` blocks,
     /// with support for complex operation pipelines and debug mode.
@@ -525,7 +529,7 @@ impl MultiTemplate {
     ///
     /// # Returns
     ///
-    /// * `Ok(MultiTemplate)` - Successfully parsed template
+    /// * `Ok(Self)` - Successfully parsed template
     /// * `Err(String)` - Parse error description
     ///
     /// # Template Syntax
@@ -622,7 +626,7 @@ impl MultiTemplate {
     /// Apply the template to input data, returning both the final string and
     /// each rendered template section result.
     ///
-    /// `rendered` is identical to the output of [`MultiTemplate::format`], while
+    /// `rendered` is identical to the output of [`Template::format`], while
     /// `template_outputs` captures the exact text inserted for each template
     /// section in left-to-right order.
     ///
@@ -849,7 +853,7 @@ impl MultiTemplate {
     ///
     /// `template_outputs` contains the exact joined output inserted for each
     /// template section after applying the same input and separator rules as
-    /// [`MultiTemplate::format_with_inputs`].
+    /// [`Template::format_with_inputs`].
     ///
     /// This is useful when callers need the final rendered string and also need
     /// to inspect or post-process the dynamic output of each template section
@@ -1498,7 +1502,7 @@ impl MultiTemplate {
     /* -------- helper: detect plain single-block templates ------------- */
 
     /// Detects and parses templates that consist of exactly one `{ ... }` block
-    /// with no surrounding literal text. Returns `Ok(Some(MultiTemplate))` when
+    /// with no surrounding literal text. Returns `Ok(Some(Self))` when
     /// the fast path can be applied, `Ok(None)` otherwise.
     fn try_single_block(template: &str) -> Result<Option<Self>, String> {
         // Must start with '{' and end with '}' to be a candidate.
@@ -1558,19 +1562,16 @@ impl Display for MultiTemplate {
 
 /* ---------- backward compatibility alias --------------------------------- */
 
-/// Type alias for backward compatibility.
+/// Preferred public type alias for template parsing and rendering.
 ///
-/// `Template` is an alias for `MultiTemplate`, providing a shorter name for the
-/// template type while maintaining compatibility with existing code.
+/// Use `Template` in new code.
 ///
 /// # Examples
 ///
 /// ```rust
 /// use string_pipeline::Template;
-/// use string_pipeline::MultiTemplate;
 ///
-/// // These are equivalent:
-/// let template1 = Template::parse("{upper}").unwrap();
-/// let template2 = MultiTemplate::parse("{upper}").unwrap();
+/// let template = Template::parse("{upper}").unwrap();
+/// assert_eq!(template.format("hello").unwrap(), "HELLO");
 /// ```
 pub type Template = MultiTemplate;

--- a/src/pipeline/template.rs
+++ b/src/pipeline/template.rs
@@ -118,7 +118,7 @@ use memchr::memchr_iter;
 /// assert_eq!(result, "a | b | c");
 /// ```
 #[derive(Debug, Clone)]
-pub struct MultiTemplate {
+pub struct Template {
     raw: String,
     sections: Vec<TemplateSection>,
     compiled_sections: Vec<CompiledSectionPlan>,
@@ -170,7 +170,7 @@ pub enum TemplateSection {
 
 impl TemplateSection {
     pub(crate) fn from_ops(ops: Vec<StringOp>) -> Self {
-        let cache_key = MultiTemplate::hash_ops(&ops);
+        let cache_key = Template::hash_ops(&ops);
         Self::Template { ops, cache_key }
     }
 }
@@ -460,7 +460,7 @@ impl RenderBuffer {
 /*  impl Template internals                                                 */
 /* ------------------------------------------------------------------------ */
 
-impl MultiTemplate {
+impl Template {
     fn new(raw: String, sections: Vec<TemplateSection>, debug: bool) -> Self {
         let compiled_sections = Self::compile_sections(&sections);
         Self {
@@ -513,7 +513,7 @@ impl MultiTemplate {
             return Ok(single);
         }
 
-        let (sections, _) = parser::parse_multi_template(template)?;
+        let (sections, _) = parser::parse_template_sections(template)?;
         Ok(Self::new(template.to_string(), sections, false))
     }
 
@@ -565,7 +565,7 @@ impl MultiTemplate {
             return Ok(single);
         }
 
-        let (sections, inner_dbg) = parser::parse_multi_template(template)?;
+        let (sections, inner_dbg) = parser::parse_template_sections(template)?;
         Ok(Self::new(
             template.to_string(),
             sections,
@@ -1554,7 +1554,7 @@ impl MultiTemplate {
 /// let template = Template::parse("Hello {upper}!").unwrap();
 /// println!("{}", template); // Prints: Hello {upper}!
 /// ```
-impl Display for MultiTemplate {
+impl Display for Template {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.raw)
     }
@@ -1562,16 +1562,12 @@ impl Display for MultiTemplate {
 
 /* ---------- backward compatibility alias --------------------------------- */
 
-/// Preferred public type alias for template parsing and rendering.
+/// Deprecated compatibility alias.
 ///
-/// Use `Template` in new code.
-///
-/// # Examples
-///
-/// ```rust
-/// use string_pipeline::Template;
-///
-/// let template = Template::parse("{upper}").unwrap();
-/// assert_eq!(template.format("hello").unwrap(), "HELLO");
-/// ```
-pub type Template = MultiTemplate;
+/// Use [`Template`] instead. `MultiTemplate` will be removed in the next major
+/// release.
+#[deprecated(
+    since = "0.14.0",
+    note = "use `Template` instead; `MultiTemplate` will be removed in the next major release"
+)]
+pub type MultiTemplate = Template;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -85,10 +85,10 @@ fn test_complex_pipeline() {
 }
 
 // ============================================================================
-// MULTI-TEMPLATE SPECIFIC TESTS
+// TEMPLATE COMPOSITION TESTS
 // ============================================================================
 #[test]
-fn test_multi_template_basic() {
+fn test_template_basic() {
     let output = run_cli(&["Hello {upper} World!", "test"]);
     assert!(output.status.success());
     assert_eq!(
@@ -98,7 +98,7 @@ fn test_multi_template_basic() {
 }
 
 #[test]
-fn test_multi_template_multiple_sections() {
+fn test_template_multiple_sections() {
     let output = run_cli(&["First: {split:,:0} Last: {split:,:1}", "apple,banana"]);
     assert!(output.status.success());
     assert_eq!(
@@ -108,7 +108,7 @@ fn test_multi_template_multiple_sections() {
 }
 
 #[test]
-fn test_multi_template_with_complex_operations() {
+fn test_template_with_complex_operations() {
     let output = run_cli(&[
         "Count: {split:,:..|map:{upper}|join:-} Items: {split:,:1..3|join:;}",
         "a,b,c,d,e",
@@ -121,7 +121,7 @@ fn test_multi_template_with_complex_operations() {
 }
 
 #[test]
-fn test_multi_template_literal_only() {
+fn test_template_literal_only() {
     let output = run_cli(&["Just plain text", "ignored"]);
     assert!(output.status.success());
     assert_eq!(
@@ -131,7 +131,7 @@ fn test_multi_template_literal_only() {
 }
 
 #[test]
-fn test_multi_template_consecutive_templates() {
+fn test_template_consecutive_templates() {
     let output = run_cli(&["{upper}{lower}", "TeSt"]);
     assert!(output.status.success());
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "TESTtest");
@@ -156,7 +156,7 @@ fn test_template_file_option() {
 }
 
 #[test]
-fn test_template_file_multi_template() {
+fn test_template_file_template() {
     let template_file = create_temp_file("Prefix: {upper} Suffix: {lower}");
     let output = run_cli_with_stdin(
         &["--template-file", template_file.path().to_str().unwrap()],
@@ -202,7 +202,7 @@ fn test_both_template_and_input_files() {
 }
 
 #[test]
-fn test_input_file_with_multi_template() {
+fn test_input_file_with_template() {
     let input_file = create_temp_file("apple,banana");
     let output = run_cli(&[
         "First: {split:,:0} Second: {split:,:1}",
@@ -228,7 +228,7 @@ fn test_debug_flag() {
 }
 
 #[test]
-fn test_debug_flag_with_multi_template() {
+fn test_debug_flag_with_template() {
     let output = run_cli(&["--debug", "Result: {upper}", "hello"]);
     assert!(output.status.success());
     assert_eq!(
@@ -361,7 +361,7 @@ fn test_validate_flag() {
 }
 
 #[test]
-fn test_validate_multi_template() {
+fn test_validate_template() {
     let output = run_cli(&["--validate", "Hello {upper} World!"]);
     assert!(output.status.success());
     assert_eq!(
@@ -585,7 +585,7 @@ fn test_unicode_input() {
 }
 
 #[test]
-fn test_unicode_in_multi_template() {
+fn test_unicode_in_template() {
     let output = run_cli(&["🎉 Result: {upper} 🎊", "café"]);
     assert!(output.status.success());
     assert_eq!(
@@ -615,7 +615,7 @@ fn test_very_long_input() {
 }
 
 #[test]
-fn test_whitespace_preservation_in_multi_template() {
+fn test_whitespace_preservation_in_template() {
     let output = run_cli(&["   Before   {trim}   After   ", "  test  "]);
     assert!(output.status.success());
     assert_eq!(
@@ -626,7 +626,7 @@ fn test_whitespace_preservation_in_multi_template() {
 
 #[test]
 fn test_template_with_literal_braces() {
-    // Test that literal braces in multi-templates work with proper escaping
+    // Test that literal braces in templates work with proper escaping
     let output = run_cli(&["literal text {upper} more literal", "hello"]);
     assert!(output.status.success());
     assert_eq!(
@@ -677,7 +677,7 @@ fn test_file_input_with_debug() {
 }
 
 #[test]
-fn test_template_file_with_multi_template_and_validation() {
+fn test_template_file_with_template_and_validation() {
     let template_file = create_temp_file("Start: {split:,:0} End: {split:,:1}");
     let output = run_cli(&[
         "--validate",

--- a/tests/multi_template_tests.rs
+++ b/tests/multi_template_tests.rs
@@ -722,6 +722,177 @@ fn test_structured_template_file_operations() {
     );
 }
 
+#[test]
+fn test_format_rich_mixed_template() {
+    let template = MultiTemplate::parse("asd {upper} bsd {lower}").unwrap();
+    let result = template.format_rich("MiXeD").unwrap();
+
+    assert_eq!(result.rendered, "asd MIXED bsd mixed");
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].template_position, 0);
+    assert_eq!(result.template_outputs[0].overall_position, 1);
+    assert_eq!(result.template_outputs[0].output, "MIXED");
+    assert_eq!(result.template_outputs[1].template_position, 1);
+    assert_eq!(result.template_outputs[1].overall_position, 3);
+    assert_eq!(result.template_outputs[1].output, "mixed");
+}
+
+#[test]
+fn test_format_rich_single_template() {
+    let template = MultiTemplate::parse("Result: {upper}").unwrap();
+    let result = template.format_rich("hello").unwrap();
+
+    assert_eq!(result.rendered, "Result: HELLO");
+    assert_eq!(result.template_outputs.len(), 1);
+    assert_eq!(result.template_outputs[0].template_position, 0);
+    assert_eq!(result.template_outputs[0].overall_position, 1);
+    assert_eq!(result.template_outputs[0].output, "HELLO");
+}
+
+#[test]
+fn test_format_rich_consecutive_templates() {
+    let template = MultiTemplate::parse("{upper}{lower}").unwrap();
+    let result = template.format_rich("TeSt").unwrap();
+
+    assert_eq!(result.rendered, "TESTtest");
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].overall_position, 0);
+    assert_eq!(result.template_outputs[1].overall_position, 1);
+    assert_eq!(result.template_outputs[0].output, "TEST");
+    assert_eq!(result.template_outputs[1].output, "test");
+}
+
+#[test]
+fn test_format_rich_literal_only_template() {
+    let template = MultiTemplate::parse("literal only").unwrap();
+    let result = template.format_rich("ignored").unwrap();
+
+    assert_eq!(result.rendered, "literal only");
+    assert!(result.template_outputs.is_empty());
+}
+
+#[test]
+fn test_format_rich_empty_template_section() {
+    let template = MultiTemplate::parse("keep {} here").unwrap();
+    let result = template.format_rich("value").unwrap();
+
+    assert_eq!(result.rendered, "keep value here");
+    assert_eq!(result.template_outputs.len(), 1);
+    assert_eq!(result.template_outputs[0].output, "value");
+    assert_eq!(result.template_outputs[0].overall_position, 1);
+}
+
+#[test]
+fn test_format_rich_repeated_template_sections() {
+    let template = MultiTemplate::parse("First: {split:,:0} Again: {split:,:0}").unwrap();
+    let result = template.format_rich("apple,banana").unwrap();
+
+    assert_eq!(result.rendered, "First: apple Again: apple");
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].output, "apple");
+    assert_eq!(result.template_outputs[1].output, "apple");
+    assert_eq!(result.template_outputs[0].template_position, 0);
+    assert_eq!(result.template_outputs[1].template_position, 1);
+}
+
+#[test]
+fn test_format_rich_complex_pipeline_outputs() {
+    let template =
+        MultiTemplate::parse("Users: {split:,:1..3|join:;} Count: {split:,:..|map:{upper}|join:-}")
+            .unwrap();
+    let result = template.format_rich("alice,bob,charlie,dave,eve").unwrap();
+
+    assert_eq!(
+        result.rendered,
+        "Users: bob;charlie Count: ALICE-BOB-CHARLIE-DAVE-EVE"
+    );
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].output, "bob;charlie");
+    assert_eq!(
+        result.template_outputs[1].output,
+        "ALICE-BOB-CHARLIE-DAVE-EVE"
+    );
+}
+
+#[test]
+fn test_format_rich_shell_variables_do_not_create_template_outputs() {
+    let template = MultiTemplate::parse("${HOME}/projects/{upper}").unwrap();
+    let result = template.format_rich("readme").unwrap();
+
+    assert_eq!(result.rendered, "${HOME}/projects/README");
+    assert_eq!(result.template_outputs.len(), 1);
+    assert_eq!(result.template_outputs[0].output, "README");
+    assert_eq!(result.template_outputs[0].overall_position, 1);
+}
+
+#[test]
+fn test_format_rich_error_propagation() {
+    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let regular_error = template.format("test").unwrap_err();
+    let rich_error = template.format_rich("test").unwrap_err();
+
+    assert_eq!(rich_error, regular_error);
+}
+
+#[test]
+fn test_format_with_inputs_rich_single_inputs() {
+    let template = MultiTemplate::parse("User: {upper} | Email: {lower}").unwrap();
+    let result = template
+        .format_with_inputs_rich(&[&["john doe"], &["JOHN@EXAMPLE.COM"]], &[" ", " "])
+        .unwrap();
+
+    assert_eq!(result.rendered, "User: JOHN DOE | Email: john@example.com");
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].output, "JOHN DOE");
+    assert_eq!(result.template_outputs[1].output, "john@example.com");
+}
+
+#[test]
+fn test_format_with_inputs_rich_multiple_values() {
+    let template = MultiTemplate::parse("Users: {upper} | Files: {lower}").unwrap();
+    let result = template
+        .format_with_inputs_rich(
+            &[&["john doe", "peter parker"], &["FILE1.TXT", "FILE2.TXT"]],
+            &[" ", ","],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.rendered,
+        "Users: JOHN DOE PETER PARKER | Files: file1.txt,file2.txt"
+    );
+    assert_eq!(result.template_outputs.len(), 2);
+    assert_eq!(result.template_outputs[0].output, "JOHN DOE PETER PARKER");
+    assert_eq!(result.template_outputs[1].output, "file1.txt,file2.txt");
+}
+
+#[test]
+fn test_format_with_inputs_rich_missing_inputs_and_default_separator() {
+    let template = MultiTemplate::parse("A: {upper} B: {lower} C: {}").unwrap();
+    let result = template
+        .format_with_inputs_rich(&[&["one"], &["TWO", "THREE"]], &[","])
+        .unwrap();
+
+    assert_eq!(result.rendered, "A: ONE B: two three C: ");
+    assert_eq!(result.template_outputs.len(), 3);
+    assert_eq!(result.template_outputs[0].output, "ONE");
+    assert_eq!(result.template_outputs[1].output, "two three");
+    assert_eq!(result.template_outputs[2].output, "");
+}
+
+#[test]
+fn test_format_with_inputs_rich_error_propagation() {
+    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let regular_error = template
+        .format_with_inputs(&[&["test"], &["input"]], &[" ", " "])
+        .unwrap_err();
+    let rich_error = template
+        .format_with_inputs_rich(&[&["test"], &["input"]], &[" ", " "])
+        .unwrap_err();
+
+    assert_eq!(rich_error, regular_error);
+}
+
 // Tests for shell variable support (${...} patterns)
 
 #[test]

--- a/tests/multi_template_tests.rs
+++ b/tests/multi_template_tests.rs
@@ -731,10 +731,10 @@ fn test_format_rich_mixed_template() {
     assert_eq!(result.template_outputs.len(), 2);
     assert_eq!(result.template_outputs[0].template_position, 0);
     assert_eq!(result.template_outputs[0].overall_position, 1);
-    assert_eq!(result.template_outputs[0].output, "MIXED");
+    assert_eq!(result.template_output(0), Some("MIXED"));
     assert_eq!(result.template_outputs[1].template_position, 1);
     assert_eq!(result.template_outputs[1].overall_position, 3);
-    assert_eq!(result.template_outputs[1].output, "mixed");
+    assert_eq!(result.template_output(1), Some("mixed"));
 }
 
 #[test]
@@ -746,7 +746,7 @@ fn test_format_rich_single_template() {
     assert_eq!(result.template_outputs.len(), 1);
     assert_eq!(result.template_outputs[0].template_position, 0);
     assert_eq!(result.template_outputs[0].overall_position, 1);
-    assert_eq!(result.template_outputs[0].output, "HELLO");
+    assert_eq!(result.template_output(0), Some("HELLO"));
 }
 
 #[test]
@@ -758,8 +758,8 @@ fn test_format_rich_consecutive_templates() {
     assert_eq!(result.template_outputs.len(), 2);
     assert_eq!(result.template_outputs[0].overall_position, 0);
     assert_eq!(result.template_outputs[1].overall_position, 1);
-    assert_eq!(result.template_outputs[0].output, "TEST");
-    assert_eq!(result.template_outputs[1].output, "test");
+    assert_eq!(result.template_output(0), Some("TEST"));
+    assert_eq!(result.template_output(1), Some("test"));
 }
 
 #[test]
@@ -778,7 +778,7 @@ fn test_format_rich_empty_template_section() {
 
     assert_eq!(result.rendered, "keep value here");
     assert_eq!(result.template_outputs.len(), 1);
-    assert_eq!(result.template_outputs[0].output, "value");
+    assert_eq!(result.template_output(0), Some("value"));
     assert_eq!(result.template_outputs[0].overall_position, 1);
 }
 
@@ -789,8 +789,8 @@ fn test_format_rich_repeated_template_sections() {
 
     assert_eq!(result.rendered, "First: apple Again: apple");
     assert_eq!(result.template_outputs.len(), 2);
-    assert_eq!(result.template_outputs[0].output, "apple");
-    assert_eq!(result.template_outputs[1].output, "apple");
+    assert_eq!(result.template_output(0), Some("apple"));
+    assert_eq!(result.template_output(1), Some("apple"));
     assert_eq!(result.template_outputs[0].template_position, 0);
     assert_eq!(result.template_outputs[1].template_position, 1);
 }
@@ -807,10 +807,10 @@ fn test_format_rich_complex_pipeline_outputs() {
         "Users: bob;charlie Count: ALICE-BOB-CHARLIE-DAVE-EVE"
     );
     assert_eq!(result.template_outputs.len(), 2);
-    assert_eq!(result.template_outputs[0].output, "bob;charlie");
+    assert_eq!(result.template_output(0), Some("bob;charlie"));
     assert_eq!(
-        result.template_outputs[1].output,
-        "ALICE-BOB-CHARLIE-DAVE-EVE"
+        result.template_output(1),
+        Some("ALICE-BOB-CHARLIE-DAVE-EVE")
     );
 }
 
@@ -821,7 +821,7 @@ fn test_format_rich_shell_variables_do_not_create_template_outputs() {
 
     assert_eq!(result.rendered, "${HOME}/projects/README");
     assert_eq!(result.template_outputs.len(), 1);
-    assert_eq!(result.template_outputs[0].output, "README");
+    assert_eq!(result.template_output(0), Some("README"));
     assert_eq!(result.template_outputs[0].overall_position, 1);
 }
 
@@ -843,8 +843,8 @@ fn test_format_with_inputs_rich_single_inputs() {
 
     assert_eq!(result.rendered, "User: JOHN DOE | Email: john@example.com");
     assert_eq!(result.template_outputs.len(), 2);
-    assert_eq!(result.template_outputs[0].output, "JOHN DOE");
-    assert_eq!(result.template_outputs[1].output, "john@example.com");
+    assert_eq!(result.template_output(0), Some("JOHN DOE"));
+    assert_eq!(result.template_output(1), Some("john@example.com"));
 }
 
 #[test]
@@ -862,8 +862,8 @@ fn test_format_with_inputs_rich_multiple_values() {
         "Users: JOHN DOE PETER PARKER | Files: file1.txt,file2.txt"
     );
     assert_eq!(result.template_outputs.len(), 2);
-    assert_eq!(result.template_outputs[0].output, "JOHN DOE PETER PARKER");
-    assert_eq!(result.template_outputs[1].output, "file1.txt,file2.txt");
+    assert_eq!(result.template_output(0), Some("JOHN DOE PETER PARKER"));
+    assert_eq!(result.template_output(1), Some("file1.txt,file2.txt"));
 }
 
 #[test]
@@ -875,9 +875,9 @@ fn test_format_with_inputs_rich_missing_inputs_and_default_separator() {
 
     assert_eq!(result.rendered, "A: ONE B: two three C: ");
     assert_eq!(result.template_outputs.len(), 3);
-    assert_eq!(result.template_outputs[0].output, "ONE");
-    assert_eq!(result.template_outputs[1].output, "two three");
-    assert_eq!(result.template_outputs[2].output, "");
+    assert_eq!(result.template_output(0), Some("ONE"));
+    assert_eq!(result.template_output(1), Some("two three"));
+    assert_eq!(result.template_output(2), Some(""));
 }
 
 #[test]

--- a/tests/template_composition_tests.rs
+++ b/tests/template_composition_tests.rs
@@ -1,34 +1,34 @@
-use string_pipeline::{MultiTemplate, SectionType};
+use string_pipeline::{SectionType, Template};
 
 #[test]
-fn test_multi_template_literal_text_only() {
+fn test_template_literal_text_only() {
     // Test with only literal text, no template sections
-    let template = MultiTemplate::parse("Just plain text without any templates").unwrap();
+    let template = Template::parse("Just plain text without any templates").unwrap();
     let result = template.format("input_ignored").unwrap();
     assert_eq!(result, "Just plain text without any templates");
 }
 
 #[test]
-fn test_multi_template_single_template_section() {
+fn test_template_single_template_section() {
     // Test with just one template section and literal text
-    let template = MultiTemplate::parse("Prefix {upper} Suffix").unwrap();
+    let template = Template::parse("Prefix {upper} Suffix").unwrap();
     let result = template.format("hello").unwrap();
     assert_eq!(result, "Prefix HELLO Suffix");
 }
 
 #[test]
-fn test_multi_template_multiple_template_sections() {
+fn test_template_multiple_template_sections() {
     // Test multiple template sections with different operations
-    let template = MultiTemplate::parse("A: {upper} B: {lower} C: {trim}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower} C: {trim}").unwrap();
     let result = template.format("  MiXeD  ").unwrap();
     assert_eq!(result, "A:   MIXED   B:   mixed   C: MiXeD");
 }
 
 #[test]
-fn test_multi_template_complex_operations() {
-    // Test complex operations within multi-template sections
+fn test_template_complex_operations() {
+    // Test complex operations within template sections
     let template =
-        MultiTemplate::parse("Users: {split:,:1..3|join:;} Count: {split:,:..|map:{upper}|join:-}")
+        Template::parse("Users: {split:,:1..3|join:;} Count: {split:,:..|map:{upper}|join:-}")
             .unwrap();
     let result = template.format("alice,bob,charlie,dave,eve").unwrap();
     assert_eq!(
@@ -38,9 +38,9 @@ fn test_multi_template_complex_operations() {
 }
 
 #[test]
-fn test_multi_template_caching_optimization() {
+fn test_template_caching_optimization() {
     // Test that split operations are cached and reused efficiently
-    let template = MultiTemplate::parse(
+    let template = Template::parse(
         "First: {split:,:0} Second: {split:,:1} Third: {split:,:0} Fourth: {split:,:2}",
     )
     .unwrap();
@@ -52,119 +52,117 @@ fn test_multi_template_caching_optimization() {
 }
 
 #[test]
-fn test_multi_template_different_separators() {
+fn test_template_different_separators() {
     // Test multiple template sections with different separators
     let template =
-        MultiTemplate::parse("Comma: {split:,:0} Space: {split: :1} Pipe: {split:|:0}").unwrap();
+        Template::parse("Comma: {split:,:0} Space: {split: :1} Pipe: {split:|:0}").unwrap();
     let result = template.format("a,b c|d").unwrap();
     assert_eq!(result, "Comma: a Space: c|d Pipe: a,b c");
 }
 
 #[test]
-fn test_multi_template_nested_braces() {
-    // Test that nested braces are handled correctly in multi-templates
-    let template =
-        MultiTemplate::parse("Result: {split:,:..|map:{upper|append:!}|join:-}").unwrap();
+fn test_template_nested_braces() {
+    // Test that nested braces are handled correctly in templates
+    let template = Template::parse("Result: {split:,:..|map:{upper|append:!}|join:-}").unwrap();
     let result = template.format("hello,world,test").unwrap();
     assert_eq!(result, "Result: HELLO!-WORLD!-TEST!");
 }
 
 #[test]
-fn test_multi_template_empty_sections() {
+fn test_template_empty_sections() {
     // Test handling of empty template sections and adjacent braces
-    let template = MultiTemplate::parse("Start {upper} Middle {lower} End").unwrap();
+    let template = Template::parse("Start {upper} Middle {lower} End").unwrap();
     let result = template.format("test").unwrap();
     assert_eq!(result, "Start TEST Middle test End");
 }
 
 #[test]
-fn test_multi_template_debug_mode() {
-    // Test debug mode functionality in multi-templates
+fn test_template_debug_mode() {
+    // Test debug mode functionality in templates
     let template =
-        MultiTemplate::parse_with_debug("Debug: {!upper} Normal: {lower}", Some(true)).unwrap();
+        Template::parse_with_debug("Debug: {!upper} Normal: {lower}", Some(true)).unwrap();
     assert!(template.is_debug());
     let result = template.format("TeSt").unwrap();
     assert_eq!(result, "Debug: TEST Normal: test");
 }
 
 #[test]
-fn test_multi_template_display_trait() {
+fn test_template_display_trait() {
     // Test Display implementation shows original template string
-    let template = MultiTemplate::parse("Hello {upper} World!").unwrap();
+    let template = Template::parse("Hello {upper} World!").unwrap();
     assert_eq!(format!("{template}"), "Hello {upper} World!");
 }
 
 #[test]
-fn test_multi_template_template_string_method() {
+fn test_template_template_string_method() {
     // Test template_string method returns original template
     let template_str = "Test {lower} Template";
-    let template = MultiTemplate::parse(template_str).unwrap();
+    let template = Template::parse(template_str).unwrap();
     assert_eq!(template.template_string(), template_str);
 }
 
 #[test]
-fn test_multi_template_section_counts() {
+fn test_template_section_counts() {
     // Test section counting methods
-    let template = MultiTemplate::parse("A {upper} B {lower} C").unwrap();
+    let template = Template::parse("A {upper} B {lower} C").unwrap();
     assert_eq!(template.section_count(), 5); // "A ", upper, " B ", lower, " C"
     assert_eq!(template.template_section_count(), 2); // upper and lower operations
 }
 
 #[test]
-fn test_multi_template_special_characters() {
-    // Test multi-templates with special characters in literal text
-    let template = MultiTemplate::parse("Price: $100 {upper} & more!").unwrap();
+fn test_template_special_characters() {
+    // Test templates with special characters in literal text
+    let template = Template::parse("Price: $100 {upper} & more!").unwrap();
     let result = template.format("discount").unwrap();
     assert_eq!(result, "Price: $100 DISCOUNT & more!");
 }
 
 #[test]
-fn test_multi_template_unicode_support() {
+fn test_template_unicode_support() {
     // Test Unicode support in both literal text and operations
-    let template = MultiTemplate::parse("🎉 Result: {upper} 🎊").unwrap();
+    let template = Template::parse("🎉 Result: {upper} 🎊").unwrap();
     let result = template.format("café").unwrap();
     assert_eq!(result, "🎉 Result: CAFÉ 🎊");
 }
 
 #[test]
-fn test_multi_template_whitespace_preservation() {
+fn test_template_whitespace_preservation() {
     // Test that whitespace in literal sections is preserved
-    let template = MultiTemplate::parse("   Before   {trim}   After   ").unwrap();
+    let template = Template::parse("   Before   {trim}   After   ").unwrap();
     let result = template.format("  test  ").unwrap();
     assert_eq!(result, "   Before   test   After   ");
 }
 
 #[test]
-fn test_multi_template_consecutive_templates() {
+fn test_template_consecutive_templates() {
     // Test consecutive template sections without literal text between them
-    let template = MultiTemplate::parse("{upper}{lower}").unwrap();
+    let template = Template::parse("{upper}{lower}").unwrap();
     let result = template.format("TeSt").unwrap();
     assert_eq!(result, "TESTtest");
 }
 
 #[test]
-fn test_multi_template_shorthand_syntax() {
-    // Test shorthand syntax within multi-templates
-    let template = MultiTemplate::parse("First: {0} Last: {-1}").unwrap();
+fn test_template_shorthand_syntax() {
+    // Test shorthand syntax within templates
+    let template = Template::parse("First: {0} Last: {-1}").unwrap();
     let result = template.format("apple banana cherry").unwrap();
     assert_eq!(result, "First: apple Last: cherry");
 }
 
 #[test]
-fn test_multi_template_range_operations() {
-    // Test range operations in multi-templates
-    let template = MultiTemplate::parse("Range: {1..3} Substring: {substring:2..5}").unwrap();
+fn test_template_range_operations() {
+    // Test range operations in templates
+    let template = Template::parse("Range: {1..3} Substring: {substring:2..5}").unwrap();
     let result = template.format("one two three four five").unwrap();
     assert_eq!(result, "Range: two three Substring: e t");
 }
 
 #[test]
-fn test_multi_template_filter_operations() {
-    // Test filter operations in multi-templates
-    let template = MultiTemplate::parse(
-        "Original: {split:,:..|join:,} Filtered: {split:,:..|filter:test|join:,}",
-    )
-    .unwrap();
+fn test_template_filter_operations() {
+    // Test filter operations in templates
+    let template =
+        Template::parse("Original: {split:,:..|join:,} Filtered: {split:,:..|filter:test|join:,}")
+            .unwrap();
     let result = template.format("apple,test1,banana,test2").unwrap();
     assert_eq!(
         result,
@@ -173,11 +171,10 @@ fn test_multi_template_filter_operations() {
 }
 
 #[test]
-fn test_multi_template_regex_operations() {
-    // Test regex operations in multi-templates
+fn test_template_regex_operations() {
+    // Test regex operations in templates
     let template =
-        MultiTemplate::parse("Numbers: {regex_extract:\\d+} Letters: {regex_extract:[a-z]+}")
-            .unwrap();
+        Template::parse("Numbers: {regex_extract:\\d+} Letters: {regex_extract:[a-z]+}").unwrap();
     let result = template.format("abc123def456").unwrap();
     assert_eq!(result, "Numbers: 123 Letters: abc");
 }
@@ -185,31 +182,31 @@ fn test_multi_template_regex_operations() {
 // Error handling tests
 
 #[test]
-fn test_multi_template_unclosed_brace_error() {
+fn test_template_unclosed_brace_error() {
     // Test error when template section is not closed
-    let result = MultiTemplate::parse("Hello {upper world");
+    let result = Template::parse("Hello {upper world");
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("Unclosed template brace"));
 }
 
 #[test]
-fn test_multi_template_invalid_operation_error() {
+fn test_template_invalid_operation_error() {
     // Test error when template section contains invalid operation
-    let result = MultiTemplate::parse("Hello {invalid_operation} World");
+    let result = Template::parse("Hello {invalid_operation} World");
     assert!(result.is_err());
 }
 
 #[test]
-fn test_multi_template_malformed_nested_braces() {
+fn test_template_malformed_nested_braces() {
     // Test error handling for malformed nested braces
-    let result = MultiTemplate::parse("Test {split:,:0|map:{upper} incomplete");
+    let result = Template::parse("Test {split:,:0|map:{upper} incomplete");
     assert!(result.is_err());
 }
 
 #[test]
-fn test_multi_template_format_error_propagation() {
+fn test_template_format_error_propagation() {
     // Test that format errors from individual sections are properly propagated
-    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let template = Template::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
     let result = template.format("test");
     assert!(result.is_err());
 }
@@ -217,19 +214,19 @@ fn test_multi_template_format_error_propagation() {
 // Integration tests with complex scenarios
 
 #[test]
-fn test_multi_template_csv_processing() {
-    // Test processing CSV-like data with multi-templates
+fn test_template_csv_processing() {
+    // Test processing CSV-like data with templates
     let template =
-        MultiTemplate::parse("Name: {split:,:0} | Age: {split:,:1} | Email: {split:,:2}").unwrap();
+        Template::parse("Name: {split:,:0} | Age: {split:,:1} | Email: {split:,:2}").unwrap();
     let result = template.format("John Doe,25,john@example.com").unwrap();
     assert_eq!(result, "Name: John Doe | Age: 25 | Email: john@example.com");
 }
 
 #[test]
-fn test_multi_template_log_processing() {
+fn test_template_log_processing() {
     // Test log processing scenario
     let template =
-        MultiTemplate::parse("[{split: :0}] Level: {split: :1} Message: {split: :2..}").unwrap();
+        Template::parse("[{split: :0}] Level: {split: :1} Message: {split: :2..}").unwrap();
     let result = template
         .format("2023-01-01 ERROR Database connection failed")
         .unwrap();
@@ -240,17 +237,17 @@ fn test_multi_template_log_processing() {
 }
 
 #[test]
-fn test_multi_template_path_processing() {
+fn test_template_path_processing() {
     // Test file path processing
-    let template = MultiTemplate::parse("Dir: {split:/:0..-1|join:/} File: {split:/:-1}").unwrap();
+    let template = Template::parse("Dir: {split:/:0..-1|join:/} File: {split:/:-1}").unwrap();
     let result = template.format("/home/user/documents/file.txt").unwrap();
     assert_eq!(result, "Dir: /home/user/documents File: file.txt");
 }
 
 #[test]
-fn test_multi_template_complex_formatting() {
+fn test_template_complex_formatting() {
     // Test complex formatting scenario combining multiple operations
-    let template = MultiTemplate::parse("Summary: {split:,:..|map:{trim|upper}|join:-} (Count: {split:,:..|map:{trim}|unique|join:,})").unwrap();
+    let template = Template::parse("Summary: {split:,:..|map:{trim|upper}|join:-} (Count: {split:,:..|map:{trim}|unique|join:,})").unwrap();
     let result = template
         .format("  apple  , banana ,  apple  , cherry ")
         .unwrap();
@@ -261,14 +258,14 @@ fn test_multi_template_complex_formatting() {
 }
 
 #[test]
-fn test_multi_template_performance_with_many_sections() {
+fn test_template_performance_with_many_sections() {
     // Test performance with many template sections (should use caching effectively)
     let sections = (0..10)
         .map(|i| format!("S{}: {{split:,:{}}}", i, i % 3))
         .collect::<Vec<_>>()
         .join(" ");
 
-    let template = MultiTemplate::parse(&sections).unwrap();
+    let template = Template::parse(&sections).unwrap();
     let result = template.format("a,b,c,d,e").unwrap();
 
     // Verify the template works and produces expected output
@@ -279,25 +276,25 @@ fn test_multi_template_performance_with_many_sections() {
 }
 
 #[test]
-fn test_multi_template_empty_input() {
+fn test_template_empty_input() {
     // Test behavior with empty input
-    let template = MultiTemplate::parse("Before: {upper} After: {lower}").unwrap();
+    let template = Template::parse("Before: {upper} After: {lower}").unwrap();
     let result = template.format("").unwrap();
     assert_eq!(result, "Before:  After: ");
 }
 
 #[test]
-fn test_multi_template_only_template_section() {
+fn test_template_only_template_section() {
     // Test when entire string is just one template section
-    let template = MultiTemplate::parse("{split:,:..|map:{upper}|join:-}").unwrap();
+    let template = Template::parse("{split:,:..|map:{upper}|join:-}").unwrap();
     let result = template.format("hello,world,test").unwrap();
     assert_eq!(result, "HELLO-WORLD-TEST");
 }
 
 #[test]
-fn test_multi_template_mixed_operations() {
+fn test_template_mixed_operations() {
     // Test that split optimization doesn't interfere with other operations
-    let template = MultiTemplate::parse("First: {0} Upper: {upper} Last: {2}").unwrap();
+    let template = Template::parse("First: {0} Upper: {upper} Last: {2}").unwrap();
     let result = template.format("hello world test").unwrap();
     assert_eq!(result, "First: hello Upper: HELLO WORLD TEST Last: test");
 }
@@ -307,7 +304,7 @@ fn test_multi_template_mixed_operations() {
 #[test]
 fn test_format_with_inputs_basic() {
     // Test basic usage of format_with_inputs (single inputs)
-    let template = MultiTemplate::parse("User: {upper} | Email: {lower}").unwrap();
+    let template = Template::parse("User: {upper} | Email: {lower}").unwrap();
     let result = template
         .format_with_inputs(&[&["john doe"], &["JOHN@EXAMPLE.COM"]], &[" ", " "])
         .unwrap();
@@ -317,7 +314,7 @@ fn test_format_with_inputs_basic() {
 #[test]
 fn test_format_with_inputs_redirect() {
     // Test basic with multiple operations
-    let template = MultiTemplate::parse("bat {strip_ansi|lower} > {}.txt").unwrap();
+    let template = Template::parse("bat {strip_ansi|lower} > {}.txt").unwrap();
     let result = template
         .format_with_inputs(&[&["MyFile.log"], &["output"]], &[" ", " "])
         .unwrap();
@@ -327,7 +324,7 @@ fn test_format_with_inputs_redirect() {
 #[test]
 fn test_format_with_inputs_multiple_values() {
     // Test multiple inputs per template section
-    let template = MultiTemplate::parse("Users: {upper} | Files: {lower}").unwrap();
+    let template = Template::parse("Users: {upper} | Files: {lower}").unwrap();
     let result = template
         .format_with_inputs(
             &[&["john doe", "peter parker"], &["FILE1.TXT", "FILE2.TXT"]],
@@ -343,7 +340,7 @@ fn test_format_with_inputs_multiple_values() {
 #[test]
 fn test_format_with_inputs_multiple_values_quoted() {
     // Test multiple inputs per template section
-    let template = MultiTemplate::parse("Users: {upper} | Files: {lower}").unwrap();
+    let template = Template::parse("Users: {upper} | Files: {lower}").unwrap();
     let result = template
         .format_with_inputs(
             &[
@@ -362,7 +359,7 @@ fn test_format_with_inputs_multiple_values_quoted() {
 #[test]
 fn test_format_with_inputs_complex_operations() {
     // Test with complex operations in each section
-    let template = MultiTemplate::parse(
+    let template = Template::parse(
         "Files: {split:,:..|filter:\\.txt$|join: \\| } Count: {split:,:..|map:{upper}|join:-}",
     )
     .unwrap();
@@ -378,7 +375,7 @@ fn test_format_with_inputs_complex_operations() {
 #[test]
 fn test_format_with_inputs_single_template() {
     // Test with just one template section
-    let template = MultiTemplate::parse("Result: {upper}").unwrap();
+    let template = Template::parse("Result: {upper}").unwrap();
     let result = template
         .format_with_inputs(&[&["hello world"]], &[" "])
         .unwrap();
@@ -388,7 +385,7 @@ fn test_format_with_inputs_single_template() {
 #[test]
 fn test_format_with_inputs_no_templates() {
     // Test with no template sections (only literals)
-    let template = MultiTemplate::parse("Just literal text").unwrap();
+    let template = Template::parse("Just literal text").unwrap();
     let result = template.format_with_inputs(&[], &[]).unwrap();
     assert_eq!(result, "Just literal text");
 }
@@ -396,7 +393,7 @@ fn test_format_with_inputs_no_templates() {
 #[test]
 fn test_format_with_inputs_multiple_sections() {
     // Test with multiple template sections
-    let template = MultiTemplate::parse("A: {upper} B: {lower} C: {trim} D: {append:!}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower} C: {trim} D: {append:!}").unwrap();
     let result = template
         .format_with_inputs(
             &[&["hello"], &["WORLD"], &["  test  "], &["done"]],
@@ -409,7 +406,7 @@ fn test_format_with_inputs_multiple_sections() {
 #[test]
 fn test_format_with_inputs_input_count_handling() {
     // Test graceful handling when input count doesn't match template section count
-    let template = MultiTemplate::parse("A: {upper} B: {lower}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower}").unwrap();
 
     // Too few inputs - should use empty string for missing inputs
     let result = template.format_with_inputs(&[&["only_one"]], &[" ", " "]);
@@ -425,7 +422,7 @@ fn test_format_with_inputs_input_count_handling() {
 #[test]
 fn test_format_with_inputs_excess_inputs() {
     // Test that excess inputs are truncated gracefully
-    let template = MultiTemplate::parse("diff {} {}").unwrap();
+    let template = Template::parse("diff {} {}").unwrap();
     let result = template.format_with_inputs(
         &[
             &["file1.txt"],
@@ -443,7 +440,7 @@ fn test_format_with_inputs_excess_inputs() {
 #[test]
 fn test_format_with_inputs_insufficient_inputs() {
     // Test that missing inputs are treated as empty strings
-    let template = MultiTemplate::parse("cmd {upper} {lower} {trim}").unwrap();
+    let template = Template::parse("cmd {upper} {lower} {trim}").unwrap();
     let result = template.format_with_inputs(
         &[
             &["arg1"],
@@ -460,7 +457,7 @@ fn test_format_with_inputs_insufficient_inputs() {
 #[test]
 fn test_format_with_inputs_empty_inputs_array() {
     // Test with completely empty inputs array
-    let template = MultiTemplate::parse("start {upper} middle {lower} end").unwrap();
+    let template = Template::parse("start {upper} middle {lower} end").unwrap();
     let result = template.format_with_inputs(&[], &[" ", " "]);
 
     assert!(result.is_ok());
@@ -470,7 +467,7 @@ fn test_format_with_inputs_empty_inputs_array() {
 #[test]
 fn test_format_with_inputs_mixed_empty_and_filled() {
     // Test with mix of empty slices and filled slices
-    let template = MultiTemplate::parse("A:{upper} B:{lower} C:{trim}").unwrap();
+    let template = Template::parse("A:{upper} B:{lower} C:{trim}").unwrap();
     let result = template.format_with_inputs(
         &[
             &[],        // Empty slice for first section
@@ -487,7 +484,7 @@ fn test_format_with_inputs_mixed_empty_and_filled() {
 #[test]
 fn test_format_with_inputs_one_to_one_mode_scenario() {
     // Test the specific scenario from the original issue
-    let template = MultiTemplate::parse("diff {} {}").unwrap();
+    let template = Template::parse("diff {} {}").unwrap();
 
     // Simulating OneToOne mode: individual slices for each input
     let inputs = ["file1.txt", "file2.txt", "file3.txt"];
@@ -503,7 +500,7 @@ fn test_format_with_inputs_one_to_one_mode_scenario() {
 #[test]
 fn test_format_with_inputs_separator_defaults() {
     // Test that missing separators default to space " "
-    let template = MultiTemplate::parse("files: {} | items: {} | values: {}").unwrap();
+    let template = Template::parse("files: {} | items: {} | values: {}").unwrap();
 
     // Provide separators for only first section
     let result = template.format_with_inputs(
@@ -525,7 +522,7 @@ fn test_format_with_inputs_separator_defaults() {
 #[test]
 fn test_format_with_inputs_no_separators_provided() {
     // Test with no separators provided - all should default to space
-    let template = MultiTemplate::parse("A: {} B: {}").unwrap();
+    let template = Template::parse("A: {} B: {}").unwrap();
 
     let result = template.format_with_inputs(&[&["one", "two", "three"], &["a", "b", "c"]], &[]); // No separators provided
 
@@ -536,7 +533,7 @@ fn test_format_with_inputs_no_separators_provided() {
 #[test]
 fn test_format_with_inputs_separator_count_handling() {
     // Test graceful handling when separator count doesn't match template section count
-    let template = MultiTemplate::parse("A: {upper} B: {lower}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower}").unwrap();
 
     // Too few separators - should use default space for missing separators
     let result = template.format_with_inputs(&[&["one"], &["two"]], &[","]);
@@ -552,7 +549,7 @@ fn test_format_with_inputs_separator_count_handling() {
 #[test]
 fn test_format_with_inputs_consecutive_templates() {
     // Test consecutive template sections without literal text
-    let template = MultiTemplate::parse("{upper}{lower}{trim}").unwrap();
+    let template = Template::parse("{upper}{lower}{trim}").unwrap();
     let result = template
         .format_with_inputs(&[&["Hello"], &["WORLD"], &["  test  "]], &[" ", " ", " "])
         .unwrap();
@@ -562,7 +559,7 @@ fn test_format_with_inputs_consecutive_templates() {
 #[test]
 fn test_format_with_inputs_empty_sections() {
     // Test empty input sections
-    let template = MultiTemplate::parse("A: {upper} B: {lower}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower}").unwrap();
     let result = template
         .format_with_inputs(&[&[], &["test"]], &[" ", " "])
         .unwrap();
@@ -572,7 +569,7 @@ fn test_format_with_inputs_empty_sections() {
 #[test]
 fn test_format_with_inputs_custom_separators() {
     // Test different separators for each section
-    let template = MultiTemplate::parse("List1: {} | List2: {}").unwrap();
+    let template = Template::parse("List1: {} | List2: {}").unwrap();
     let result = template
         .format_with_inputs(&[&["a", "b", "c"], &["x", "y", "z"]], &["-", "|"])
         .unwrap();
@@ -582,7 +579,7 @@ fn test_format_with_inputs_custom_separators() {
 #[test]
 fn test_format_with_inputs_processing_error() {
     // Test that processing errors are properly propagated
-    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let template = Template::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
     let result = template.format_with_inputs(&[&["test"], &["input"]], &[" ", " "]);
     assert!(result.is_err());
 }
@@ -590,7 +587,7 @@ fn test_format_with_inputs_processing_error() {
 #[test]
 fn test_get_template_sections() {
     // Test introspection method for template sections
-    let template = MultiTemplate::parse("Hello {upper} world {lower|trim} end").unwrap();
+    let template = Template::parse("Hello {upper} world {lower|trim} end").unwrap();
     let sections = template.get_template_sections();
 
     assert_eq!(sections.len(), 2);
@@ -603,7 +600,7 @@ fn test_get_template_sections() {
 #[test]
 fn test_get_template_sections_empty() {
     // Test with no template sections
-    let template = MultiTemplate::parse("Just literal text with no templates").unwrap();
+    let template = Template::parse("Just literal text with no templates").unwrap();
     let sections = template.get_template_sections();
     assert_eq!(sections.len(), 0);
 }
@@ -611,7 +608,7 @@ fn test_get_template_sections_empty() {
 #[test]
 fn test_get_section_info() {
     // Test detailed section info method
-    let template = MultiTemplate::parse("Start {upper} middle {lower} end").unwrap();
+    let template = Template::parse("Start {upper} middle {lower} end").unwrap();
     let info = template.get_section_info();
 
     assert_eq!(info.len(), 5);
@@ -646,7 +643,7 @@ fn test_get_section_info() {
 #[test]
 fn test_get_section_info_only_templates() {
     // Test section info with only template sections
-    let template = MultiTemplate::parse("{upper}{lower}").unwrap();
+    let template = Template::parse("{upper}{lower}").unwrap();
     let info = template.get_section_info();
 
     assert_eq!(info.len(), 2);
@@ -659,7 +656,7 @@ fn test_get_section_info_only_templates() {
 #[test]
 fn test_backwards_compatibility_maintained() {
     // Test that existing format() method still works exactly as before
-    let template = MultiTemplate::parse("Hello {upper} world {lower}!").unwrap();
+    let template = Template::parse("Hello {upper} world {lower}!").unwrap();
     let result_old = template.format("test").unwrap();
     assert_eq!(result_old, "Hello TEST world test!");
 
@@ -672,8 +669,7 @@ fn test_backwards_compatibility_maintained() {
 fn test_structured_template_complex_scenario() {
     // Test a complex real-world scenario
     let template =
-        MultiTemplate::parse("cp {split:/:-1} /backup/{split:/:-1|replace:s/\\.txt$/.bak/}")
-            .unwrap();
+        Template::parse("cp {split:/:-1} /backup/{split:/:-1|replace:s/\\.txt$/.bak/}").unwrap();
     let result = template
         .format_with_inputs(
             &[
@@ -695,7 +691,7 @@ fn test_structured_template_complex_scenario() {
 #[test]
 fn test_structured_template_data_processing() {
     // Test structured processing for data transformation
-    let template = MultiTemplate::parse("Name: {split:,:..|slice:0..1|join:} Age: {split:,:..|slice:1..2|join:} Email: {split:,:..|slice:2..3|join:}").unwrap();
+    let template = Template::parse("Name: {split:,:..|slice:0..1|join:} Age: {split:,:..|slice:1..2|join:} Email: {split:,:..|slice:2..3|join:}").unwrap();
     let csv_data = "John Doe,30,john@example.com";
     let result = template
         .format_with_inputs(&[&[csv_data], &[csv_data], &[csv_data]], &[" ", " ", " "])
@@ -706,7 +702,7 @@ fn test_structured_template_data_processing() {
 #[test]
 fn test_structured_template_file_operations() {
     // Test file operation template
-    let template = MultiTemplate::parse("mkdir -p {split:/:..-1|join:/} && touch {}.tmp").unwrap();
+    let template = Template::parse("mkdir -p {split:/:..-1|join:/} && touch {}.tmp").unwrap();
     let result = template
         .format_with_inputs(
             &[
@@ -724,7 +720,7 @@ fn test_structured_template_file_operations() {
 
 #[test]
 fn test_format_rich_mixed_template() {
-    let template = MultiTemplate::parse("asd {upper} bsd {lower}").unwrap();
+    let template = Template::parse("asd {upper} bsd {lower}").unwrap();
     let result = template.format_rich("MiXeD").unwrap();
 
     assert_eq!(result.rendered, "asd MIXED bsd mixed");
@@ -739,7 +735,7 @@ fn test_format_rich_mixed_template() {
 
 #[test]
 fn test_format_rich_single_template() {
-    let template = MultiTemplate::parse("Result: {upper}").unwrap();
+    let template = Template::parse("Result: {upper}").unwrap();
     let result = template.format_rich("hello").unwrap();
 
     assert_eq!(result.rendered, "Result: HELLO");
@@ -751,7 +747,7 @@ fn test_format_rich_single_template() {
 
 #[test]
 fn test_format_rich_consecutive_templates() {
-    let template = MultiTemplate::parse("{upper}{lower}").unwrap();
+    let template = Template::parse("{upper}{lower}").unwrap();
     let result = template.format_rich("TeSt").unwrap();
 
     assert_eq!(result.rendered, "TESTtest");
@@ -764,7 +760,7 @@ fn test_format_rich_consecutive_templates() {
 
 #[test]
 fn test_format_rich_literal_only_template() {
-    let template = MultiTemplate::parse("literal only").unwrap();
+    let template = Template::parse("literal only").unwrap();
     let result = template.format_rich("ignored").unwrap();
 
     assert_eq!(result.rendered, "literal only");
@@ -773,7 +769,7 @@ fn test_format_rich_literal_only_template() {
 
 #[test]
 fn test_format_rich_empty_template_section() {
-    let template = MultiTemplate::parse("keep {} here").unwrap();
+    let template = Template::parse("keep {} here").unwrap();
     let result = template.format_rich("value").unwrap();
 
     assert_eq!(result.rendered, "keep value here");
@@ -784,7 +780,7 @@ fn test_format_rich_empty_template_section() {
 
 #[test]
 fn test_format_rich_repeated_template_sections() {
-    let template = MultiTemplate::parse("First: {split:,:0} Again: {split:,:0}").unwrap();
+    let template = Template::parse("First: {split:,:0} Again: {split:,:0}").unwrap();
     let result = template.format_rich("apple,banana").unwrap();
 
     assert_eq!(result.rendered, "First: apple Again: apple");
@@ -798,7 +794,7 @@ fn test_format_rich_repeated_template_sections() {
 #[test]
 fn test_format_rich_complex_pipeline_outputs() {
     let template =
-        MultiTemplate::parse("Users: {split:,:1..3|join:;} Count: {split:,:..|map:{upper}|join:-}")
+        Template::parse("Users: {split:,:1..3|join:;} Count: {split:,:..|map:{upper}|join:-}")
             .unwrap();
     let result = template.format_rich("alice,bob,charlie,dave,eve").unwrap();
 
@@ -816,7 +812,7 @@ fn test_format_rich_complex_pipeline_outputs() {
 
 #[test]
 fn test_format_rich_shell_variables_do_not_create_template_outputs() {
-    let template = MultiTemplate::parse("${HOME}/projects/{upper}").unwrap();
+    let template = Template::parse("${HOME}/projects/{upper}").unwrap();
     let result = template.format_rich("readme").unwrap();
 
     assert_eq!(result.rendered, "${HOME}/projects/README");
@@ -827,7 +823,7 @@ fn test_format_rich_shell_variables_do_not_create_template_outputs() {
 
 #[test]
 fn test_format_rich_error_propagation() {
-    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let template = Template::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
     let regular_error = template.format("test").unwrap_err();
     let rich_error = template.format_rich("test").unwrap_err();
 
@@ -836,7 +832,7 @@ fn test_format_rich_error_propagation() {
 
 #[test]
 fn test_format_with_inputs_rich_single_inputs() {
-    let template = MultiTemplate::parse("User: {upper} | Email: {lower}").unwrap();
+    let template = Template::parse("User: {upper} | Email: {lower}").unwrap();
     let result = template
         .format_with_inputs_rich(&[&["john doe"], &["JOHN@EXAMPLE.COM"]], &[" ", " "])
         .unwrap();
@@ -849,7 +845,7 @@ fn test_format_with_inputs_rich_single_inputs() {
 
 #[test]
 fn test_format_with_inputs_rich_multiple_values() {
-    let template = MultiTemplate::parse("Users: {upper} | Files: {lower}").unwrap();
+    let template = Template::parse("Users: {upper} | Files: {lower}").unwrap();
     let result = template
         .format_with_inputs_rich(
             &[&["john doe", "peter parker"], &["FILE1.TXT", "FILE2.TXT"]],
@@ -868,7 +864,7 @@ fn test_format_with_inputs_rich_multiple_values() {
 
 #[test]
 fn test_format_with_inputs_rich_missing_inputs_and_default_separator() {
-    let template = MultiTemplate::parse("A: {upper} B: {lower} C: {}").unwrap();
+    let template = Template::parse("A: {upper} B: {lower} C: {}").unwrap();
     let result = template
         .format_with_inputs_rich(&[&["one"], &["TWO", "THREE"]], &[","])
         .unwrap();
@@ -882,7 +878,7 @@ fn test_format_with_inputs_rich_missing_inputs_and_default_separator() {
 
 #[test]
 fn test_format_with_inputs_rich_error_propagation() {
-    let template = MultiTemplate::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
+    let template = Template::parse("Valid: {upper} Invalid: {regex_extract:[}").unwrap();
     let regular_error = template
         .format_with_inputs(&[&["test"], &["input"]], &[" ", " "])
         .unwrap_err();
@@ -896,65 +892,65 @@ fn test_format_with_inputs_rich_error_propagation() {
 // Tests for shell variable support (${...} patterns)
 
 #[test]
-fn test_multi_template_shell_variable_basic() {
+fn test_template_shell_variable_basic() {
     // Test basic shell variable pattern ${VAR}
-    let template = MultiTemplate::parse("${HOME}/projects/{upper}").unwrap();
+    let template = Template::parse("${HOME}/projects/{upper}").unwrap();
     let result = template.format("readme").unwrap();
     assert_eq!(result, "${HOME}/projects/README");
 }
 
 #[test]
-fn test_multi_template_shell_variable_with_default() {
+fn test_template_shell_variable_with_default() {
     // Test shell variable with default value ${VAR:-default}
-    let template = MultiTemplate::parse("${EDITOR:-vim} {upper}.txt").unwrap();
+    let template = Template::parse("${EDITOR:-vim} {upper}.txt").unwrap();
     let result = template.format("config").unwrap();
     assert_eq!(result, "${EDITOR:-vim} CONFIG.txt");
 }
 
 #[test]
-fn test_multi_template_shell_variable_specific_case() {
+fn test_template_shell_variable_specific_case() {
     // Test the specific case that was failing: ${EDITOR:-vim} {}
-    let template = MultiTemplate::parse("${EDITOR:-vim} {}").unwrap();
+    let template = Template::parse("${EDITOR:-vim} {}").unwrap();
     let result = template.format("file.txt").unwrap();
     assert_eq!(result, "${EDITOR:-vim} file.txt");
 }
 
 #[test]
-fn test_multi_template_multiple_shell_variables() {
+fn test_template_multiple_shell_variables() {
     // Test multiple shell variables in one template
-    let template = MultiTemplate::parse("${USER}@${HOST}: {upper}").unwrap();
+    let template = Template::parse("${USER}@${HOST}: {upper}").unwrap();
     let result = template.format("hello world").unwrap();
     assert_eq!(result, "${USER}@${HOST}: HELLO WORLD");
 }
 
 #[test]
-fn test_multi_template_shell_variable_complex() {
+fn test_template_shell_variable_complex() {
     // Test complex shell variable expressions
-    let template = MultiTemplate::parse("${PATH:+/usr/bin:}${HOME}/bin {lower}").unwrap();
+    let template = Template::parse("${PATH:+/usr/bin:}${HOME}/bin {lower}").unwrap();
     let result = template.format("SCRIPT").unwrap();
     assert_eq!(result, "${PATH:+/usr/bin:}${HOME}/bin script");
 }
 
 #[test]
-fn test_multi_template_shell_variable_empty() {
+fn test_template_shell_variable_empty() {
     // Test empty shell variable ${}
-    let template = MultiTemplate::parse("${} prefix {upper}").unwrap();
+    let template = Template::parse("${} prefix {upper}").unwrap();
     let result = template.format("test").unwrap();
     assert_eq!(result, "${} prefix TEST");
 }
 
 #[test]
-fn test_multi_template_shell_variable_nested_braces() {
+fn test_template_shell_variable_nested_braces() {
     // Test shell variables with nested braces
-    let template = MultiTemplate::parse("${CONFIG_DIR:-${HOME}/.config} {lower}").unwrap();
+    let template = Template::parse("${CONFIG_DIR:-${HOME}/.config} {lower}").unwrap();
     let result = template.format("APP").unwrap();
     assert_eq!(result, "${CONFIG_DIR:-${HOME}/.config} app");
 }
 
 #[test]
-fn test_multi_template_shell_variable_mixed_with_templates() {
+fn test_template_shell_variable_mixed_with_templates() {
     // Test mixing shell variables with multiple template sections
-    let template = MultiTemplate::parse("cp {upper} ${BACKUP_DIR:-/backup}/{lower}.bak").unwrap();
+    let template = Template::parse("cp {upper} ${BACKUP_DIR:-/backup}/{lower}.bak").unwrap();
     let result = template.format("important.txt").unwrap();
     assert_eq!(
         result,
@@ -963,33 +959,33 @@ fn test_multi_template_shell_variable_mixed_with_templates() {
 }
 
 #[test]
-fn test_multi_template_shell_variable_at_boundaries() {
+fn test_template_shell_variable_at_boundaries() {
     // Test shell variables at start/end of template
-    let template = MultiTemplate::parse("${PREFIX} middle {upper} ${SUFFIX}").unwrap();
+    let template = Template::parse("${PREFIX} middle {upper} ${SUFFIX}").unwrap();
     let result = template.format("test").unwrap();
     assert_eq!(result, "${PREFIX} middle TEST ${SUFFIX}");
 }
 
 #[test]
-fn test_multi_template_shell_variable_consecutive() {
+fn test_template_shell_variable_consecutive() {
     // Test consecutive shell variables
-    let template = MultiTemplate::parse("${VAR1}${VAR2} {upper}").unwrap();
+    let template = Template::parse("${VAR1}${VAR2} {upper}").unwrap();
     let result = template.format("hello").unwrap();
     assert_eq!(result, "${VAR1}${VAR2} HELLO");
 }
 
 #[test]
-fn test_multi_template_shell_variable_special_characters() {
+fn test_template_shell_variable_special_characters() {
     // Test shell variables with special characters
-    let template = MultiTemplate::parse("${HOME}/some-dir/sub_dir {upper}").unwrap();
+    let template = Template::parse("${HOME}/some-dir/sub_dir {upper}").unwrap();
     let result = template.format("file name").unwrap();
     assert_eq!(result, "${HOME}/some-dir/sub_dir FILE NAME");
 }
 
 #[test]
-fn test_multi_template_shell_variable_real_world_example() {
+fn test_template_shell_variable_real_world_example() {
     // Test real-world shell command example
-    let template = MultiTemplate::parse("${EDITOR:-nano} ${HOME}/.config/{lower}.conf").unwrap();
+    let template = Template::parse("${EDITOR:-nano} ${HOME}/.config/{lower}.conf").unwrap();
     let result = template.format("MYAPP").unwrap();
     assert_eq!(result, "${EDITOR:-nano} ${HOME}/.config/myapp.conf");
 }
@@ -997,9 +993,9 @@ fn test_multi_template_shell_variable_real_world_example() {
 // Error handling tests for shell variables
 
 #[test]
-fn test_multi_template_unclosed_shell_variable_error() {
+fn test_template_unclosed_shell_variable_error() {
     // Test error when shell variable is not closed
-    let result = MultiTemplate::parse("${HOME unclosed {upper}");
+    let result = Template::parse("${HOME unclosed {upper}");
     assert!(result.is_err());
     assert!(
         result
@@ -1009,12 +1005,11 @@ fn test_multi_template_unclosed_shell_variable_error() {
 }
 
 #[test]
-fn test_multi_template_shell_variable_complex_nesting() {
+fn test_template_shell_variable_complex_nesting() {
     // Test complex nesting of shell variables and templates
-    let template = MultiTemplate::parse(
-        "${DIR:-${HOME}/default} contains {split:,:..|filter:\\.txt$|join: and }",
-    )
-    .unwrap();
+    let template =
+        Template::parse("${DIR:-${HOME}/default} contains {split:,:..|filter:\\.txt$|join: and }")
+            .unwrap();
     let result = template
         .format("file1.txt,doc.pdf,file2.txt,readme.md")
         .unwrap();


### PR DESCRIPTION
## Summary

This PR adds a rich rendering path for templates and makes `Template` the canonical public API.

The main driver is enabling downstream callers such as to distinguish literal template text from rendered template substitutions, so they can safely escape only the dynamic parts when building shell commands.

## Changes

- Add rich formatting results for template pipelines
- Expose per-template rendered outputs alongside the final rendered string
- Store rich template outputs as borrowed slices/ranges into the final rendered buffer instead of duplicating strings
- Add accessors for rich results instead of requiring callers to depend on raw struct layout
- Document the rich rendering APIs in the README, crate docs, and template system guide
- Rename the public API to consistently use `Template`
- Deprecate `MultiTemplate` as a compatibility alias, with removal planned for the next major release
- Add `parse_template_sections` as the canonical parser helper and deprecate `parse_multi_template`